### PR TITLE
Changed creation of target directories during installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ lint:
 ## Internal targets
 
 target_folders:
-	@mkdir $(PREFIX)/{bin,lib,include} -p
+	@mkdir -p $(PREFIX)/bin $(PREFIX)/lib $(PREFIX)/include
 
 build_directories:
 	@mkdir -p $(objdirs) ./lib ./bin ./log ./tests/tmp


### PR DESCRIPTION
Encountered the following error during installation in an ubuntu-22.04 machine:

```
$ PREFIX=/data1/SOFT/test make install
 [...]
 cp: target '/data1/SOFT/test/bin' is not a directory
 make: *** [Makefile:119: install] Error 1
```

The resulting failed installation creates an empty folder named '{bin,lib,include}'. It corrects by changing line [Makefile#L167](https://github.com/CBDD/rDock/blob/eb979e0aac26ed8b8127e390063c2adfbcd2553a/Makefile#L167) in my setup.