### PR TITLE
Introduce Section intermediate object to `RbtParameterFileSource`

### DIFF
--- a/include/RbtFileError.h
+++ b/include/RbtFileError.h
@@ -22,6 +22,8 @@ const RbtString IDS_FILE_READ_ERROR = "RBT_FILE_READ_ERROR";
 const RbtString IDS_FILE_WRITE_ERROR = "RBT_FILE_WRITE_ERROR";
 const RbtString IDS_FILE_PARSE_ERROR = "RBT_FILE_PARSE_ERROR";
 const RbtString IDS_FILE_MISSING_PARAMETER = "RBT_FILE_MISSING_PARAMETER";
+const RbtString IDS_FILE_UNKNOWN_SECTION = "RBT_FILE_UNKNOWN_SECTION";
+const RbtString IDS_FILE_SECTION_NOT_SET = "RBT_FILE_SECTION_NOT_SET";
 const RbtString IDS_DIR_NOACCESS = "RBT_DIR_NOACCESS";
 const RbtString IDS_NO_FILEINDIR = "RBT_NO_FILEINDIR";
 const RbtString IDS_NOENV = "RBT_NO_ENVIRONMENT";
@@ -64,6 +66,19 @@ class RbtFileMissingParameter: public RbtFileError {
  public:
     RbtFileMissingParameter(const RbtString& strFile, RbtInt nLine, const RbtString& strMessage = ""):
         RbtFileError(IDS_FILE_MISSING_PARAMETER, strFile, nLine, strMessage) {}
+};
+
+// Missing parameter error
+class RbtFileSectionNotSet: public RbtFileError {
+ public:
+    RbtFileSectionNotSet(const RbtString& strFile, RbtInt nLine, const RbtString& strMessage = ""):
+        RbtFileError(IDS_FILE_SECTION_NOT_SET, strFile, nLine, strMessage) {}
+};
+
+class RbtFileUnknownSection: public RbtFileError {
+ public:
+    RbtFileUnknownSection(const RbtString& strFile, RbtInt nLine, const RbtString& strMessage = ""):
+        RbtFileError(IDS_FILE_UNKNOWN_SECTION, strFile, nLine, strMessage) {}
 };
 
 // Exceptions for RbtDirectorySource and derived classes:

--- a/include/RbtFileError.h
+++ b/include/RbtFileError.h
@@ -68,13 +68,6 @@ class RbtFileMissingParameter: public RbtFileError {
         RbtFileError(IDS_FILE_MISSING_PARAMETER, strFile, nLine, strMessage) {}
 };
 
-// Missing parameter error
-class RbtFileSectionNotSet: public RbtFileError {
- public:
-    RbtFileSectionNotSet(const RbtString& strFile, RbtInt nLine, const RbtString& strMessage = ""):
-        RbtFileError(IDS_FILE_SECTION_NOT_SET, strFile, nLine, strMessage) {}
-};
-
 class RbtFileUnknownSection: public RbtFileError {
  public:
     RbtFileUnknownSection(const RbtString& strFile, RbtInt nLine, const RbtString& strMessage = ""):

--- a/include/RbtParameterFileSource.h
+++ b/include/RbtParameterFileSource.h
@@ -82,7 +82,7 @@ class RbtParameterFileSource: public RbtBaseFileSource {
     // Checks if name already contains a section name, if so just returns the name unchanged
     // If not, prefixes the name with the current section name
     RbtString GetFullParameterName(const RbtString& strParamName);
-    Section & getSectionByName(const std::string& name) const;
+    Section & getSectionByName(const std::string& name);
     RbtVariant getCurrentSectionParameter(const std::string& name);
 
  protected:
@@ -93,7 +93,7 @@ class RbtParameterFileSource: public RbtBaseFileSource {
     RbtString m_strTitle;
     RbtString m_strVersion;
     std::vector<Section> sections;
-    std::unordered_map<const std::string&, Section&> section_name_mapping;
+    std::unordered_map<std::string, size_t> section_name_mapping;
     Section* current_section;
 };
 

--- a/include/RbtParameterFileSource.h
+++ b/include/RbtParameterFileSource.h
@@ -22,7 +22,7 @@ class RbtParameterFileSource: public RbtBaseFileSource {
 
    struct Section {
       std::string name;
-      std::unordered_map<std::string, RbtVariant> params;
+      std::map<std::string, RbtVariant> params;
 
 
       Section(const std::string& name): name{name}{};
@@ -83,7 +83,7 @@ class RbtParameterFileSource: public RbtBaseFileSource {
     // If not, prefixes the name with the current section name
     RbtString GetFullParameterName(const RbtString& strParamName);
     Section & getSectionByName(const std::string& name);
-    RbtVariant getCurrentSectionParameter(const std::string& name);
+    RbtVariant getParameter(const std::string& name);
 
  protected:
     // Protected data
@@ -92,8 +92,9 @@ class RbtParameterFileSource: public RbtBaseFileSource {
     // Private data
     RbtString m_strTitle;
     RbtString m_strVersion;
+    std::map<std::string, RbtVariant> parameters;
     std::vector<Section> sections;
-    std::unordered_map<std::string, size_t> section_name_mapping;
+    std::map<std::string, size_t> section_name_mapping;
     Section* current_section;
 };
 

--- a/include/RbtParameterFileSource.h
+++ b/include/RbtParameterFileSource.h
@@ -20,15 +20,13 @@
 
 class RbtParameterFileSource: public RbtBaseFileSource {
 
+ public:
    struct Section {
-      std::string name;
+      const std::string name;
       std::map<std::string, RbtVariant> params;
-
 
       Section(const std::string& name): name{name}{};
    };
-
- public:
     // Constructors
     RbtParameterFileSource(const char* fileName);
     RbtParameterFileSource(const RbtString& fileName);
@@ -63,8 +61,8 @@ class RbtParameterFileSource: public RbtBaseFileSource {
     // and need the same parameters to appear in each
     RbtInt GetNumSections();                            // Number of named sections
     RbtStringList GetSectionList();                     // List of section names
-    RbtString GetCurrentSectionName() const;                       // Get current section name
-    void SetCurrentSection(const RbtString& strSection = "");  // Set current section name
+    const RbtString& GetCurrentSectionName() const;                       // Get current section name
+    void SetCurrentSection(const RbtString& section_name = "");  // Set current section name
 
  protected:
     // Protected methods
@@ -92,10 +90,11 @@ class RbtParameterFileSource: public RbtBaseFileSource {
     // Private data
     RbtString m_strTitle;
     RbtString m_strVersion;
-    std::map<std::string, RbtVariant> parameters;
+    // Section for parameters defined at file level. Seems to 
+    Section global_section = Section("");
     std::vector<Section> sections;
     std::map<std::string, size_t> section_name_mapping;
-    Section* current_section;
+    Section* current_section = &global_section;
 };
 
 // useful typedefs

--- a/include/RbtParameterFileSource.h
+++ b/include/RbtParameterFileSource.h
@@ -19,6 +19,15 @@
 #include "RbtVariant.h"
 
 class RbtParameterFileSource: public RbtBaseFileSource {
+
+   struct Section {
+      std::string name;
+      std::unordered_map<std::string, RbtVariant> params;
+
+
+      Section(const std::string& name): name{name}{};
+   };
+
  public:
     // Constructors
     RbtParameterFileSource(const char* fileName);
@@ -54,8 +63,8 @@ class RbtParameterFileSource: public RbtBaseFileSource {
     // and need the same parameters to appear in each
     RbtInt GetNumSections();                            // Number of named sections
     RbtStringList GetSectionList();                     // List of section names
-    RbtString GetSection() const;                       // Get current section name
-    void SetSection(const RbtString& strSection = "");  // Set current section name
+    RbtString GetCurrentSectionName() const;                       // Get current section name
+    void SetCurrentSection(const RbtString& strSection = "");  // Set current section name
 
  protected:
     // Protected methods
@@ -69,13 +78,12 @@ class RbtParameterFileSource: public RbtBaseFileSource {
     // Pure virtual in RbtBaseFileSource - needs to be defined here
     virtual void Parse();
     void ClearParamsCache();
-    // Add a new section name
-    // Throws an error if section name is empty, or is a duplicate
-    void AddSection(const RbtString& strSection);
     // Returns the fully qualified parameter name (<section>::<parameter name>)
     // Checks if name already contains a section name, if so just returns the name unchanged
     // If not, prefixes the name with the current section name
     RbtString GetFullParameterName(const RbtString& strParamName);
+    Section & getSectionByName(const std::string& name) const;
+    RbtVariant getCurrentSectionParameter(const std::string& name);
 
  protected:
     // Protected data
@@ -84,9 +92,9 @@ class RbtParameterFileSource: public RbtBaseFileSource {
     // Private data
     RbtString m_strTitle;
     RbtString m_strVersion;
-    RbtStringVariantMap m_paramsMap;
-    RbtStringList m_sectionNames;  // List(vector) of section names
-    RbtString m_strSection;        // Current section
+    std::vector<Section> sections;
+    std::unordered_map<const std::string&, Section&> section_name_mapping;
+    Section* current_section;
 };
 
 // useful typedefs

--- a/src/exe/rbcalcgrid.cxx
+++ b/src/exe/rbcalcgrid.cxx
@@ -167,7 +167,7 @@ int main(int argc, char* argv[]) {
         cout << endl << "SCORING FUNCTION DETAILS:" << endl << *spSF << endl;
 
         // Create the receptor model from the file names in the receptor parameter file
-        spRecepPrmSource->SetSection();
+        spRecepPrmSource->SetCurrentSection();
         RbtPRMFactory prmFactory(spRecepPrmSource);
         RbtModelPtr spReceptor = prmFactory.CreateReceptor();
         // Trap multiple receptor conformations here: this SF does not support them yet

--- a/src/exe/rbcavity.cxx
+++ b/src/exe/rbcavity.cxx
@@ -124,7 +124,7 @@ void RBCavity(const RBCavityConfig &config) {
     );
 
     // Create the receptor model from the file names in the parameter file
-    spRecepPrmSource->SetSection();
+    spRecepPrmSource->SetCurrentSection();
     RbtPRMFactory prmFactory(spRecepPrmSource);
     RbtModelPtr spReceptor = prmFactory.CreateReceptor();
 

--- a/src/exe/rbdock.cxx
+++ b/src/exe/rbdock.cxx
@@ -307,7 +307,7 @@ int main(int argc, const char *argv[]) {
         // Default directory is $RBT_ROOT/data/sf
         RbtSFFactoryPtr spSFFactory(new RbtSFFactory());  // Factory class for scoring functions
         RbtSFAggPtr spSF(new RbtSFAgg(_ROOT_SF));         // Root SF aggregate
-        spParamSource->SetSection(_ROOT_SF);
+        spParamSource->SetCurrentSection(_ROOT_SF);
         RbtStringList sfList(spParamSource->GetParameterList());
         // Loop over all parameters in the SCORE section
         for (RbtStringListConstIter sfIter = sfList.begin(); sfIter != sfList.end(); sfIter++) {
@@ -323,7 +323,7 @@ int main(int argc, const char *argv[]) {
 
         // Create the docking transform aggregate from the transform definitions in the docking prm file
         RbtTransformFactoryPtr spTransformFactory(new RbtTransformFactory());
-        spParamSource->SetSection();
+        spParamSource->SetCurrentSection();
         RbtTransformAggPtr spTransform(spTransformFactory->CreateAggFromFile(spParamSource, _ROOT_TRANSFORM));
 
         // Override the TRACE levels for the scoring function and transform
@@ -350,7 +350,7 @@ int main(int argc, const char *argv[]) {
         RbtVariant vPrm(spParamSource->GetFileName());
         RbtVariant vDir(Rbt::GetCurrentDirectory());
 
-        spRecepPrmSource->SetSection();
+        spRecepPrmSource->SetCurrentSection();
         // Read docking site from file and register with workspace
         RbtString strASFile = spWS->GetName() + ".as";
         RbtString strInputFile = Rbt::GetRbtFileName("data/grids", strASFile);

--- a/src/exe/rbmoegrid.cxx
+++ b/src/exe/rbmoegrid.cxx
@@ -187,7 +187,7 @@ int main(int argc, char* argv[]) {
             cout << endl << "SCORING FUNCTION DETAILS:" << endl << *spSF << endl;
 
             // Create the receptor model from the file names in the receptor parameter file
-            spRecepPrmSource->SetSection();
+            spRecepPrmSource->SetCurrentSection();
             RbtPRMFactory prmFactory(spRecepPrmSource);
             RbtModelPtr spReceptor = prmFactory.CreateReceptor();
 

--- a/src/lib/RbtBaseMolecularFileSource.cxx
+++ b/src/lib/RbtBaseMolecularFileSource.cxx
@@ -346,7 +346,7 @@ void RbtBaseMolecularFileSource::SetupPartialIonicGroups(RbtAtomList& atoms, Rbt
         return;
     }
 
-    spParamSource->SetSection(subunitName);
+    spParamSource->SetCurrentSection(subunitName);
     RbtStringList atList = spParamSource->GetParameterList();
     if (std::find(atList.begin(), atList.end(), _MANDATORY) != atList.end()) {
         RbtString mandatory = spParamSource->GetParameterValueAsString(_MANDATORY);

--- a/src/lib/RbtDihedralSF.cxx
+++ b/src/lib/RbtDihedralSF.cxx
@@ -168,7 +168,7 @@ RbtDihedral::prms RbtDihedralSF::FindDihedralParams(
     RbtString str23 = str2 + "_" + str3;
     RbtString str32 = str3 + "_" + str2;
     if (std::find(m_centralPairs.begin(), m_centralPairs.end(), str23) != m_centralPairs.end()) {
-        m_spDihedralSource->SetSection(str23);
+        m_spDihedralSource->SetCurrentSection(str23);
         RbtString str14 = str1 + "_" + str4;
         RbtString str1w = str1 + "_" + wild;
         RbtString strw4 = wild + "_" + str4;
@@ -198,7 +198,7 @@ RbtDihedral::prms RbtDihedralSF::FindDihedralParams(
             }
         }
     } else if (std::find(m_centralPairs.begin(), m_centralPairs.end(), str32) != m_centralPairs.end()) {
-        m_spDihedralSource->SetSection(str32);
+        m_spDihedralSource->SetCurrentSection(str32);
         RbtString str41 = str4 + "_" + str1;
         RbtString str4w = str4 + "_" + wild;
         RbtString strw1 = wild + "_" + str1;
@@ -228,7 +228,7 @@ RbtDihedral::prms RbtDihedralSF::FindDihedralParams(
             }
         }
     } else {
-        m_spDihedralSource->SetSection();
+        m_spDihedralSource->SetCurrentSection();
         strParams = m_spDihedralSource->GetParameterValueAsString("DEFAULT");
         if (iTrace > 0) {
             cout << _CT << ": No match for " << str23 << ": using DEFAULT params" << endl;

--- a/src/lib/RbtPRMFactory.cxx
+++ b/src/lib/RbtPRMFactory.cxx
@@ -50,7 +50,6 @@ RbtModelPtr RbtPRMFactory::CreateReceptor() {
     // Detect if we have an ensemble of receptor coordinate files defined
     RbtBool bEnsemble = m_pParamSource->isParameterPresent(_REC_NUM_COORD_FILES)
                         && (m_pParamSource->GetParameterValue(_REC_NUM_COORD_FILES) > 0);
-
     // Read topology and coordinates from a single molecular file source
     if (m_pParamSource->isParameterPresent(_REC_FILE)) {
         if (m_iTrace > 0) {

--- a/src/lib/RbtPRMFactory.cxx
+++ b/src/lib/RbtPRMFactory.cxx
@@ -46,7 +46,7 @@ RbtPRMFactory::RbtPRMFactory(RbtParameterFileSource* pParamSource, RbtDockingSit
     m_iTrace(0) {}
 RbtModelPtr RbtPRMFactory::CreateReceptor() {
     RbtModelPtr retVal;
-    m_pParamSource->SetSection(_REC_SECTION);
+    m_pParamSource->SetCurrentSection(_REC_SECTION);
     // Detect if we have an ensemble of receptor coordinate files defined
     RbtBool bEnsemble = m_pParamSource->isParameterPresent(_REC_NUM_COORD_FILES)
                         && (m_pParamSource->GetParameterValue(_REC_NUM_COORD_FILES) > 0);
@@ -166,7 +166,7 @@ RbtModelPtr RbtPRMFactory::CreateLigand(RbtBaseMolecularFileSource* pSource) {
 
 RbtModelList RbtPRMFactory::CreateSolvent() {
     RbtModelList retVal;
-    m_pParamSource->SetSection(_SOLV_SECTION);
+    m_pParamSource->SetCurrentSection(_SOLV_SECTION);
     if (m_pParamSource->isParameterPresent(_SOLV_FILE)) {
         RbtString strFile = m_pParamSource->GetParameterValueAsString(_SOLV_FILE);
         if (m_iTrace > 0) {
@@ -260,7 +260,7 @@ RbtModelList RbtPRMFactory::CreateSolvent() {
 }
 
 void RbtPRMFactory::AttachReceptorFlexData(RbtModel* pReceptor) {
-    m_pParamSource->SetSection(_REC_SECTION);
+    m_pParamSource->SetCurrentSection(_REC_SECTION);
     // Check whether flexible receptor is requested (terminal OH/NH3)
     // Parameter value is the range from the docking volume to include
     if (m_pParamSource->isParameterPresent(_REC_FLEX_DISTANCE)) {
@@ -286,7 +286,7 @@ void RbtPRMFactory::AttachReceptorFlexData(RbtModel* pReceptor) {
 }
 
 void RbtPRMFactory::AttachLigandFlexData(RbtModel* pLigand) {
-    m_pParamSource->SetSection(_LIG_SECTION);
+    m_pParamSource->SetCurrentSection(_LIG_SECTION);
     RbtStringList paramList = m_pParamSource->GetParameterList();
     RbtFlexData* pFlexData = new RbtLigandFlexData(m_pDS);
     for (RbtStringListConstIter iter = paramList.begin(); iter != paramList.end(); ++iter) {
@@ -300,7 +300,7 @@ void RbtPRMFactory::AttachLigandFlexData(RbtModel* pLigand) {
 }
 
 void RbtPRMFactory::AttachSolventFlexData(RbtModel* pSolvent) {
-    m_pParamSource->SetSection(_SOLV_SECTION);
+    m_pParamSource->SetCurrentSection(_SOLV_SECTION);
     RbtStringList paramList = m_pParamSource->GetParameterList();
     RbtFlexData* pFlexData = new RbtSolventFlexData(m_pDS);
     // Determine the occupancy and flexibility mode on a per-solvent basis

--- a/src/lib/RbtParameterFileSource.cxx
+++ b/src/lib/RbtParameterFileSource.cxx
@@ -52,12 +52,13 @@ RbtUInt RbtParameterFileSource::GetNumParameters() {
 // DM 06 June 2000 - limit parameters to those in current section
 RbtStringList RbtParameterFileSource::GetParameterList() {
     Parse();
-    std::vector<std::string> parameters;
+    std::vector<std::string> output;
+    for (auto& it : parameters) output.emplace_back(it.second);
     if (current_section != nullptr) {
         for (auto& it : current_section->params)
-            parameters.emplace_back(it.second);
+            output.emplace_back(it.second);
     }
-    return parameters;
+    return output;
 }
 
 RbtVariant RbtParameterFileSource::getParameter(const std::string& name) {

--- a/src/lib/RbtParameterFileSource.cxx
+++ b/src/lib/RbtParameterFileSource.cxx
@@ -53,11 +53,8 @@ RbtUInt RbtParameterFileSource::GetNumParameters() {
 RbtStringList RbtParameterFileSource::GetParameterList() {
     Parse();
     std::vector<std::string> output;
-    for (auto& it : parameters) output.emplace_back(it.second);
-    if (current_section != nullptr) {
-        for (auto& it : current_section->params)
-            output.emplace_back(it.second);
-    }
+    auto params = (current_section == nullptr) ? parameters : current_section->params;
+    for (auto& it : params) output.emplace_back(it.first);
     return output;
 }
 

--- a/src/lib/RbtParameterFileSource.cxx
+++ b/src/lib/RbtParameterFileSource.cxx
@@ -134,12 +134,12 @@ void RbtParameterFileSource::SetCurrentSection(const RbtString& strSection) {
         current_section = &getSectionByName(strSection);
 }
 
-RbtParameterFileSource::Section & RbtParameterFileSource::getSectionByName(const std::string& name) const {
+RbtParameterFileSource::Section & RbtParameterFileSource::getSectionByName(const std::string& name) {
     auto it = section_name_mapping.find(name);
     if (it == section_name_mapping.end())
         throw RbtFileUnknownSection(_WHERE_, name);
     else
-        return it->second;
+        return sections[it->second];
 }
 
 // Private methods
@@ -203,8 +203,8 @@ void RbtParameterFileSource::Parse() {
                     else if (section_name_mapping.find(section_name) != section_name_mapping.end())
                         throw RbtFileParseError(_WHERE_, "Duplicate " + section_name + " SECTION name in " + GetFileName());
                     else {
+                        section_name_mapping.insert({section_name, sections.size()});
                         sections.emplace_back(section_name);
-                        section_name_mapping[sections.back().name] = sections.back();
                         SetCurrentSection(section_name);
                     }
                 }
@@ -224,7 +224,7 @@ void RbtParameterFileSource::Parse() {
                     // Prefix the parameter name with the section name and ::
                     // Hopefully, this will ensure unique parameter names between sections
                     std::string fullyQualifiedParamName = GetFullParameterName(strParamName);
-                    current_section->params[strParamName] = RbtVariant(strParamValue);
+                    current_section->params.insert({strParamName, RbtVariant(strParamValue)});
 #ifdef _DEBUG
                     // cout << strParamName<< " = " << dParamValue << endl;
 #endif  //_DEBUG

--- a/src/lib/RbtSAIdxSF.cxx
+++ b/src/lib/RbtSAIdxSF.cxx
@@ -536,7 +536,7 @@ void RbtSAIdxSF::Setup() {
 
     for (RbtInt i = RbtHHSType::UNDEFINED; i < RbtHHSType::MAXTYPES; i++) {
         RbtString stri = hhsType.Type2Str(RbtHHSType::eType(i));
-        m_spSolvSource->SetSection(stri);
+        m_spSolvSource->SetCurrentSection(stri);
         RbtDouble r = m_spSolvSource->GetParameterValue(_R);
         RbtDouble p = m_spSolvSource->GetParameterValue(_P);
         RbtDouble asp = m_spSolvSource->GetParameterValue(_ASP);

--- a/src/lib/RbtSFFactory.cxx
+++ b/src/lib/RbtSFFactory.cxx
@@ -137,7 +137,7 @@ RbtSFAgg* RbtSFFactory::CreateAggFromFile(
     RbtSFAgg* pSFAgg(new RbtSFAgg(strName));
 
     for (RbtStringListConstIter sfIter = sfList.begin(); sfIter != sfList.end(); sfIter++) {
-        spPrmSource->SetSection(*sfIter);
+        spPrmSource->SetCurrentSection(*sfIter);
         // Check if this section is a valid scoring function definition
         if (spPrmSource->isParameterPresent(_SF)) {
             RbtString strSFClass(spPrmSource->GetParameterValueAsString(_SF));

--- a/src/lib/RbtSiteMapperFactory.cxx
+++ b/src/lib/RbtSiteMapperFactory.cxx
@@ -42,8 +42,8 @@ RbtSiteMapper* RbtSiteMapperFactory::Create(const RbtString& strMapperClass, con
 // remaining parameter values in the current section
 // Note: the current section is restored to its original value upon exit
 RbtSiteMapper* RbtSiteMapperFactory::CreateFromFile(RbtParameterFileSourcePtr spPrmSource, const RbtString& strName) {
-    RbtString strOrigSection(spPrmSource->GetSection());
-    spPrmSource->SetSection(strName);
+    RbtString strOrigSection(spPrmSource->GetCurrentSectionName());
+    spPrmSource->SetCurrentSection(strName);
     if (spPrmSource->isParameterPresent(_MAPPER)) {
         RbtString strMapperClass(spPrmSource->GetParameterValueAsString(_MAPPER));
         // Create new site mapper according to the string value of _MAPPER parameter
@@ -55,10 +55,10 @@ RbtSiteMapper* RbtSiteMapperFactory::CreateFromFile(RbtParameterFileSourcePtr sp
                 pSiteMapper->SetParameter(*prmIter, spPrmSource->GetParameterValueAsString(*prmIter));
             }
         }
-        spPrmSource->SetSection(strOrigSection);
+        spPrmSource->SetCurrentSection(strOrigSection);
         return pSiteMapper;
     } else {
-        spPrmSource->SetSection(strOrigSection);
+        spPrmSource->SetCurrentSection(strOrigSection);
         throw RbtFileMissingParameter(_WHERE_, "Missing " + _MAPPER + " parameter in section " + strName);
     }
 }

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -76,7 +76,7 @@ RbtTransformAgg* RbtTransformFactory::CreateAggFromFile(
     RbtTransformAgg* pTransformAgg(new RbtTransformAgg(strName));
 
     for (RbtStringListConstIter tIter = transformList.begin(); tIter != transformList.end(); tIter++) {
-        spPrmSource->SetSection(*tIter);
+        spPrmSource->SetCurrentSection(*tIter);
         // Check if this section is a valid scoring function definition
         if (spPrmSource->isParameterPresent(_TRANSFORM)) {
             RbtString strTransformClass(spPrmSource->GetParameterValueAsString(_TRANSFORM));

--- a/src/lib/RbtVdwSF.cxx
+++ b/src/lib/RbtVdwSF.cxx
@@ -281,7 +281,7 @@ void RbtVdwSF::Setup() {
     for (RbtInt i = RbtTriposAtomType::UNDEFINED; i < RbtTriposAtomType::MAXTYPES; i++) {
         // Read the params for atom type i
         RbtString stri = triposType.Type2Str(RbtTriposAtomType::eType(i));
-        m_spVdwSource->SetSection(stri);
+        m_spVdwSource->SetCurrentSection(stri);
         RbtDouble Ri = m_spVdwSource->GetParameterValue(_R);  // vdw radius
         RbtDouble Ki = m_spVdwSource->GetParameterValue(_K);  // Tripos 5.2 well depth
         RbtBool hasIPi = m_spVdwSource->isParameterPresent(_IP);
@@ -296,7 +296,7 @@ void RbtVdwSF::Setup() {
         for (RbtInt j = i; j < RbtTriposAtomType::MAXTYPES; j++) {
             // Read the params for atom type j
             RbtString strj = triposType.Type2Str(RbtTriposAtomType::eType(j));
-            m_spVdwSource->SetSection(strj);
+            m_spVdwSource->SetCurrentSection(strj);
             RbtDouble Rj = m_spVdwSource->GetParameterValue(_R);  // vdw radius
             RbtDouble Kj = m_spVdwSource->GetParameterValue(_K);  // Tripos 5.2 well depth
             RbtBool hasIPj = m_spVdwSource->isParameterPresent(_IP);


### PR DESCRIPTION
As a first step to parse parameter files into properly-typed data structures and not need a stateful parser I've introduced a `Section` object inside `RbtParameterFileSource` that corresponds to each one of the sections in the parameter file.

To avoid shotgunning changes all over the code I've maintained the API of RbtParameterFileSource but internally data is stored inside `Section` objects. Then we can start using this objects from outside the code and progressively move out of the current implementation. Also I reckon we can type this further, we'll discover how as we keep breaking down the filesource.