### PR TITLE
Add diagram of the Transform class hierarchy

### DIFF
--- a/diagrams/transforms-class-hierarchy.md
+++ b/diagrams/transforms-class-hierarchy.md
@@ -1,0 +1,21 @@
+```mermaid
+classDiagram
+    RbtParamHandler <|-- RbtBaseObject
+    RbtObserver <|-- RbtBaseObject
+    RbtRequestHandler <|-- RbtBaseObject
+
+    RbtBaseObject <|-- RbtBaseTransform
+    RbtBaseTransform <|-- RbtBaseBiMolTransform
+    RbtBaseTransform <|-- RbtBaseUniMolTransform
+    RbtBaseTransform <|-- RbtBNullTransform
+    RbtBaseTransform <|-- RbtTransformAgg
+
+    RbtBaseUniMolTransform <|-- RbtRandLigTransform
+
+    RbtBaseBiMolTransform <|-- RbtSimAnnTransform
+    RbtBaseBiMolTransform <|-- RbtAlignTransform
+    RbtBaseBiMolTransform <|-- RbtGATransform
+    RbtBaseBiMolTransform <|-- RbtRandPopTransform
+    RbtBaseBiMolTransform <|-- RbtSimplexTransform 
+
+```


### PR DESCRIPTION
Attempting to better organize ideas, I generated a Mermaid diagram of the Tranform class hierarchy and thought that it could be useful to have it in the repo. We can update them with relevant info if useful.