### PR TITLE
Refactor: Make transform configurations explicit, rework parsing of transforms

### DIFF
--- a/include/RbtAlignTransform.h
+++ b/include/RbtAlignTransform.h
@@ -27,22 +27,21 @@ class RbtAlignTransform: public RbtBaseBiMolTransform {
     static RbtString _COM;
     static RbtString _AXES;
 
-    enum LigandCenterOfMassTranslationStrategy { ALIGN, RANDOM };
-    enum LigandAxesAlignmentStrategy { ALIGN, RANDOM };
+    enum LigandCenterOfMassPlacementStrategy { COM_ALIGN, COM_RANDOM };
+    enum LigandAxesAlignmentStrategy { AXES_ALIGN, AXES_RANDOM };
 
     struct Config {
-      LigandCenterOfMassTranslationStrategy translation_strategy;
+      LigandCenterOfMassPlacementStrategy center_of_mass_placement_strategy;
       LigandAxesAlignmentStrategy axes_alignment_strategy;
     };
 
     static constexpr Config DEFAULT_CONFIG {
-      .translation_strategy = LigandCenterOfMassTranslationStrategy::ALIGN,
-      .axes_alignment_strategy = LigandAxesAlignmentStrategy::RANDOM,
+      .center_of_mass_placement_strategy = LigandCenterOfMassPlacementStrategy::COM_ALIGN,
+      .axes_alignment_strategy = LigandAxesAlignmentStrategy::AXES_ALIGN,
     };
 
     ////////////////////////////////////////
     // Constructors/destructors
-    RbtAlignTransform(const RbtString& strName = "ALIGN");
     RbtAlignTransform(const RbtString& strName, const Config& config);
     virtual ~RbtAlignTransform();
 

--- a/include/RbtAlignTransform.h
+++ b/include/RbtAlignTransform.h
@@ -31,8 +31,9 @@ class RbtAlignTransform: public RbtBaseBiMolTransform {
     enum LigandAxesAlignmentStrategy { AXES_ALIGN, AXES_RANDOM };
 
     struct Config {
-      LigandCenterOfMassPlacementStrategy center_of_mass_placement_strategy {LigandCenterOfMassPlacementStrategy::COM_ALIGN};
-      LigandAxesAlignmentStrategy axes_alignment_strategy {LigandAxesAlignmentStrategy::AXES_ALIGN};
+        LigandCenterOfMassPlacementStrategy center_of_mass_placement_strategy{
+            LigandCenterOfMassPlacementStrategy::COM_ALIGN};
+        LigandAxesAlignmentStrategy axes_alignment_strategy{LigandAxesAlignmentStrategy::AXES_ALIGN};
     };
 
     static const Config DEFAULT_CONFIG;

--- a/include/RbtAlignTransform.h
+++ b/include/RbtAlignTransform.h
@@ -27,9 +27,23 @@ class RbtAlignTransform: public RbtBaseBiMolTransform {
     static RbtString _COM;
     static RbtString _AXES;
 
+    enum LigandCenterOfMassTranslationStrategy { ALIGN, RANDOM };
+    enum LigandAxesAlignmentStrategy { ALIGN, RANDOM };
+
+    struct Config {
+      LigandCenterOfMassTranslationStrategy translation_strategy;
+      LigandAxesAlignmentStrategy axes_alignment_strategy;
+    };
+
+    static constexpr Config DEFAULT_CONFIG {
+      .translation_strategy = LigandCenterOfMassTranslationStrategy::ALIGN,
+      .axes_alignment_strategy = LigandAxesAlignmentStrategy::RANDOM,
+    };
+
     ////////////////////////////////////////
     // Constructors/destructors
     RbtAlignTransform(const RbtString& strName = "ALIGN");
+    RbtAlignTransform(const RbtString& strName, const Config& config);
     virtual ~RbtAlignTransform();
 
     ////////////////////////////////////////
@@ -66,10 +80,7 @@ class RbtAlignTransform: public RbtBaseBiMolTransform {
     RbtIntList m_cumulSize;    // Cumulative sizes, for weighted probabilities
     RbtInt m_totalSize;        // Total size of all cavities
 
-    // Transform parameters
-    // TODO: Make this enums
-    RbtString center_of_mass_translation;
-    RbtString axes_alignment;
+    const Config config;
 };
 
 // Useful typedefs

--- a/include/RbtAlignTransform.h
+++ b/include/RbtAlignTransform.h
@@ -31,14 +31,11 @@ class RbtAlignTransform: public RbtBaseBiMolTransform {
     enum LigandAxesAlignmentStrategy { AXES_ALIGN, AXES_RANDOM };
 
     struct Config {
-      LigandCenterOfMassPlacementStrategy center_of_mass_placement_strategy;
-      LigandAxesAlignmentStrategy axes_alignment_strategy;
+      LigandCenterOfMassPlacementStrategy center_of_mass_placement_strategy {LigandCenterOfMassPlacementStrategy::COM_ALIGN};
+      LigandAxesAlignmentStrategy axes_alignment_strategy {LigandAxesAlignmentStrategy::AXES_ALIGN};
     };
 
-    static constexpr Config DEFAULT_CONFIG {
-      .center_of_mass_placement_strategy = LigandCenterOfMassPlacementStrategy::COM_ALIGN,
-      .axes_alignment_strategy = LigandAxesAlignmentStrategy::AXES_ALIGN,
-    };
+    static const Config DEFAULT_CONFIG;
 
     ////////////////////////////////////////
     // Constructors/destructors

--- a/include/RbtAlignTransform.h
+++ b/include/RbtAlignTransform.h
@@ -65,6 +65,11 @@ class RbtAlignTransform: public RbtBaseBiMolTransform {
     RbtCavityList m_cavities;  // List of active site cavities to choose from
     RbtIntList m_cumulSize;    // Cumulative sizes, for weighted probabilities
     RbtInt m_totalSize;        // Total size of all cavities
+
+    // Transform parameters
+    // TODO: Make this enums
+    RbtString center_of_mass_translation;
+    RbtString axes_alignment;
 };
 
 // Useful typedefs

--- a/include/RbtGATransform.h
+++ b/include/RbtGATransform.h
@@ -44,28 +44,18 @@ class RbtGATransform: public RbtBaseBiMolTransform {
     static RbtString _HISTORY_FREQ;
 
     struct Config {
-      RbtDouble population_size_fraction_as_new_individuals_per_cycle;
-      RbtDouble crossover_probability;
-      RbtBool cauchy_mutation_after_crossover;
-      RbtBool use_cauchy_distribution_for_mutations; // We might want to make this an enum
-      RbtDouble relative_step_size;
-      RbtDouble equality_threshold;
-      RbtInt max_cycles;
-      RbtInt num_convergence_cycles;
-      RbtInt history_frequency;
+      RbtDouble population_size_fraction_as_new_individuals_per_cycle = 0.5;
+      RbtDouble crossover_probability = 0.4;
+      RbtBool cauchy_mutation_after_crossover = true;
+      RbtBool use_cauchy_distribution_for_mutations = false; // We might want to make this an enum
+      RbtDouble relative_step_size = 1.0;
+      RbtDouble equality_threshold = 0.1;
+      RbtInt max_cycles = 100;
+      RbtInt num_convergence_cycles = 6;
+      RbtInt history_frequency = 0;
     };
 
-    static constexpr Config DEFAULT_CONFIG {
-      .population_size_fraction_as_new_individuals_per_cycle = 0.5,
-      .crossover_probability = 0.4,
-      .cauchy_mutation_after_crossover = true,
-      .use_cauchy_distribution_for_mutations = false,
-      .relative_step_size = 1.0,
-      .equality_threshold = 0.1,
-      .max_cycles = 100,
-      .num_convergence_cycles = 6,
-      .history_frequency = 0,
-    };
+    static const Config DEFAULT_CONFIG;
 
     ////////////////////////////////////////
     // Constructors/destructors

--- a/include/RbtGATransform.h
+++ b/include/RbtGATransform.h
@@ -44,15 +44,15 @@ class RbtGATransform: public RbtBaseBiMolTransform {
     static RbtString _HISTORY_FREQ;
 
     struct Config {
-        RbtDouble population_size_fraction_as_new_individuals_per_cycle = 0.5;
-        RbtDouble crossover_probability = 0.4;
-        RbtBool cauchy_mutation_after_crossover = true;
-        RbtBool use_cauchy_distribution_for_mutations = false;  // We might want to make this an enum
-        RbtDouble relative_step_size = 1.0;
-        RbtDouble equality_threshold = 0.1;
-        RbtInt max_cycles = 100;
-        RbtInt num_convergence_cycles = 6;
-        RbtInt history_frequency = 0;
+        RbtDouble population_size_fraction_as_new_individuals_per_cycle {0.5};
+        RbtDouble crossover_probability {0.4};
+        RbtBool cauchy_mutation_after_crossover {true};
+        RbtBool use_cauchy_distribution_for_mutations {false};  // We might want to make this an enum
+        RbtDouble relative_step_size {1.0};
+        RbtDouble equality_threshold {0.1};
+        RbtInt max_cycles {100};
+        RbtInt num_convergence_cycles {6};
+        RbtInt history_frequency {0};
     };
 
     static const Config DEFAULT_CONFIG;

--- a/include/RbtGATransform.h
+++ b/include/RbtGATransform.h
@@ -43,10 +43,34 @@ class RbtGATransform: public RbtBaseBiMolTransform {
     // Output the best pose every _HISTORY_FREQ cycles.
     static RbtString _HISTORY_FREQ;
 
+    struct Config {
+      RbtDouble population_size_fraction_as_new_individuals_per_cycle;
+      RbtDouble crossover_probability;
+      RbtBool cauchy_mutation_after_crossover;
+      RbtBool use_cauchy_distribution_for_mutations; // We might want to make this an enum
+      RbtDouble relative_step_size;
+      RbtDouble equality_threshold;
+      RbtInt max_cycles;
+      RbtInt num_convergence_cycles;
+      RbtInt history_frequency;
+    };
+
+    static constexpr Config DEFAULT_CONFIG {
+      .population_size_fraction_as_new_individuals_per_cycle = 0.5,
+      .crossover_probability = 0.4,
+      .cauchy_mutation_after_crossover = true,
+      .use_cauchy_distribution_for_mutations = false,
+      .relative_step_size = 1.0,
+      .equality_threshold = 0.1,
+      .max_cycles = 100,
+      .num_convergence_cycles = 6,
+      .history_frequency = 0,
+    };
+
     ////////////////////////////////////////
     // Constructors/destructors
     ////////////////////////////////////////
-    RbtGATransform(const RbtString& strName = "GAGENRW");
+    RbtGATransform(const RbtString& strName, const Config& config);
     virtual ~RbtGATransform();
 
  protected:
@@ -67,16 +91,7 @@ class RbtGATransform: public RbtBaseBiMolTransform {
 
  private:
     RbtRand& m_rand;
-
-    RbtDouble population_size_fraction_AS_new_individuals_per_cycle;
-    RbtDouble crossover_probability;
-    RbtBool cauchy_mutation_after_crossover;
-    RbtBool use_cauchy_distribution_for_mutations; // We might want to make this an enum
-    RbtDouble relative_step_size;
-    RbtDouble equality_threshold;
-    RbtInt max_cycles;
-    RbtInt num_convergence_cycles;
-    RbtInt history_frequency;
+    const Config config;
 
 };
 

--- a/include/RbtGATransform.h
+++ b/include/RbtGATransform.h
@@ -44,15 +44,15 @@ class RbtGATransform: public RbtBaseBiMolTransform {
     static RbtString _HISTORY_FREQ;
 
     struct Config {
-      RbtDouble population_size_fraction_as_new_individuals_per_cycle = 0.5;
-      RbtDouble crossover_probability = 0.4;
-      RbtBool cauchy_mutation_after_crossover = true;
-      RbtBool use_cauchy_distribution_for_mutations = false; // We might want to make this an enum
-      RbtDouble relative_step_size = 1.0;
-      RbtDouble equality_threshold = 0.1;
-      RbtInt max_cycles = 100;
-      RbtInt num_convergence_cycles = 6;
-      RbtInt history_frequency = 0;
+        RbtDouble population_size_fraction_as_new_individuals_per_cycle = 0.5;
+        RbtDouble crossover_probability = 0.4;
+        RbtBool cauchy_mutation_after_crossover = true;
+        RbtBool use_cauchy_distribution_for_mutations = false;  // We might want to make this an enum
+        RbtDouble relative_step_size = 1.0;
+        RbtDouble equality_threshold = 0.1;
+        RbtInt max_cycles = 100;
+        RbtInt num_convergence_cycles = 6;
+        RbtInt history_frequency = 0;
     };
 
     static const Config DEFAULT_CONFIG;
@@ -82,7 +82,6 @@ class RbtGATransform: public RbtBaseBiMolTransform {
  private:
     RbtRand& m_rand;
     const Config config;
-
 };
 
 #endif  //_RBTGATRANSFORM_H_

--- a/include/RbtGATransform.h
+++ b/include/RbtGATransform.h
@@ -44,15 +44,15 @@ class RbtGATransform: public RbtBaseBiMolTransform {
     static RbtString _HISTORY_FREQ;
 
     struct Config {
-        RbtDouble population_size_fraction_as_new_individuals_per_cycle {0.5};
-        RbtDouble crossover_probability {0.4};
-        RbtBool cauchy_mutation_after_crossover {true};
-        RbtBool use_cauchy_distribution_for_mutations {false};  // We might want to make this an enum
-        RbtDouble relative_step_size {1.0};
-        RbtDouble equality_threshold {0.1};
-        RbtInt max_cycles {100};
-        RbtInt num_convergence_cycles {6};
-        RbtInt history_frequency {0};
+        RbtDouble population_size_fraction_as_new_individuals_per_cycle{0.5};
+        RbtDouble crossover_probability{0.4};
+        RbtBool cauchy_mutation_after_crossover{true};
+        RbtBool use_cauchy_distribution_for_mutations{false};  // We might want to make this an enum
+        RbtDouble relative_step_size{1.0};
+        RbtDouble equality_threshold{0.1};
+        RbtInt max_cycles{100};
+        RbtInt num_convergence_cycles{6};
+        RbtInt history_frequency{0};
     };
 
     static const Config DEFAULT_CONFIG;

--- a/include/RbtGATransform.h
+++ b/include/RbtGATransform.h
@@ -67,6 +67,17 @@ class RbtGATransform: public RbtBaseBiMolTransform {
 
  private:
     RbtRand& m_rand;
+
+    RbtDouble population_size_fraction_AS_new_individuals_per_cycle;
+    RbtDouble crossover_probability;
+    RbtBool cauchy_mutation_after_crossover;
+    RbtBool use_cauchy_distribution_for_mutations; // We might want to make this an enum
+    RbtDouble relative_step_size;
+    RbtDouble equality_threshold;
+    RbtInt max_cycles;
+    RbtInt num_convergence_cycles;
+    RbtInt history_frequency;
+
 };
 
 #endif  //_RBTGATRANSFORM_H_

--- a/include/RbtParameterFileSource.h
+++ b/include/RbtParameterFileSource.h
@@ -43,17 +43,17 @@ class RbtParameterFileSource: public RbtBaseFileSource {
     // DM 12 Feb 1999 Get a particular named parameter value as a string
     RbtString GetParameterValueAsString(const RbtString& strParamName);
 
-   RbtVariant GetParameterValueAsVariant(const RbtString& strParamName);
+    RbtVariant GetParameterValueAsVariant(const RbtString& strParamName);
     // DM 11 Feb 1999 Check if parameter is present
     RbtBool isParameterPresent(const RbtString& strParamName);
 
-    template<typename ParamType>
+    template <typename ParamType>
     ParamType GetParamOrDefault(const RbtString& paramName, const ParamType& defaultValue) {
-         if (isParameterPresent(paramName)) {
+        if (isParameterPresent(paramName)) {
             return GetParameterValueAsVariant(paramName);
-         } else {
+        } else {
             return defaultValue;
-         }
+        }
     }
 
     // DM 11 Feb 1999 - section handling

--- a/include/RbtParameterFileSource.h
+++ b/include/RbtParameterFileSource.h
@@ -42,8 +42,19 @@ class RbtParameterFileSource: public RbtBaseFileSource {
     RbtDouble GetParameterValue(const RbtString& strParamName);
     // DM 12 Feb 1999 Get a particular named parameter value as a string
     RbtString GetParameterValueAsString(const RbtString& strParamName);
+
+   RbtVariant GetParameterValueAsVariant(const RbtString& strParamName);
     // DM 11 Feb 1999 Check if parameter is present
     RbtBool isParameterPresent(const RbtString& strParamName);
+
+    template<typename ParamType>
+    ParamType GetParamOrDefault(const RbtString& paramName, const ParamType& defaultValue) {
+         if (isParameterPresent(paramName)) {
+            return GetParameterValueAsVariant(paramName);
+         } else {
+            return defaultValue;
+         }
+    }
 
     // DM 11 Feb 1999 - section handling
     // Parameters can be grouped into named sections

--- a/include/RbtRandLigTransform.h
+++ b/include/RbtRandLigTransform.h
@@ -27,12 +27,10 @@ class RbtRandLigTransform: public RbtBaseUniMolTransform {
     static RbtString _TORS_STEP;
 
     struct Config {
-      RbtDouble torsion_step;
+      RbtDouble torsion_step {180.0};
     };
 
-    static constexpr Config DEFAULT_CONFIG {
-      .torsion_step = 180.0,
-    };
+    static const Config DEFAULT_CONFIG;
 
     ////////////////////////////////////////
     // Constructors/destructors

--- a/include/RbtRandLigTransform.h
+++ b/include/RbtRandLigTransform.h
@@ -60,6 +60,10 @@ class RbtRandLigTransform: public RbtBaseUniMolTransform {
     //////////////
     RbtRand& m_rand;  // keep a reference to the singleton random number generator
     RbtBondList m_rotableBonds;
+
+    // Transform parameters
+    RbtDouble torsion_step;
+
 };
 
 // Useful typedefs

--- a/include/RbtRandLigTransform.h
+++ b/include/RbtRandLigTransform.h
@@ -26,9 +26,18 @@ class RbtRandLigTransform: public RbtBaseUniMolTransform {
     // Parameter names
     static RbtString _TORS_STEP;
 
+    struct Config {
+      RbtDouble torsion_step;
+    };
+
+    static constexpr Config DEFAULT_CONFIG {
+      .torsion_step = 180.0,
+    };
+
     ////////////////////////////////////////
     // Constructors/destructors
     RbtRandLigTransform(const RbtString& strName = "RANDLIG");
+    RbtRandLigTransform(const RbtString& strName, const Config& config);
     virtual ~RbtRandLigTransform();
 
     ////////////////////////////////////////
@@ -61,8 +70,7 @@ class RbtRandLigTransform: public RbtBaseUniMolTransform {
     RbtRand& m_rand;  // keep a reference to the singleton random number generator
     RbtBondList m_rotableBonds;
 
-    // Transform parameters
-    RbtDouble torsion_step;
+    const Config config;
 
 };
 

--- a/include/RbtRandLigTransform.h
+++ b/include/RbtRandLigTransform.h
@@ -27,7 +27,7 @@ class RbtRandLigTransform: public RbtBaseUniMolTransform {
     static RbtString _TORS_STEP;
 
     struct Config {
-      RbtDouble torsion_step {180.0};
+        RbtDouble torsion_step{180.0};
     };
 
     static const Config DEFAULT_CONFIG;
@@ -69,7 +69,6 @@ class RbtRandLigTransform: public RbtBaseUniMolTransform {
     RbtBondList m_rotableBonds;
 
     const Config config;
-
 };
 
 // Useful typedefs

--- a/include/RbtRandPopTransform.h
+++ b/include/RbtRandPopTransform.h
@@ -23,9 +23,17 @@ class RbtRandPopTransform: public RbtBaseBiMolTransform {
     static RbtString _POP_SIZE;
     static RbtString _SCALE_CHROM_LENGTH;
 
-    ////////////////////////////////////////
-    // Constructors/destructors
-    RbtRandPopTransform(const RbtString& strName = "RANDPOP");
+    struct Config {
+      RbtInt population_size;
+      RbtBool scale_chromosome_length;
+    };
+
+    static constexpr Config DEFAULT_CONFIG {
+      .population_size = 50,
+      .scale_chromosome_length = true,
+    };
+
+    RbtRandPopTransform(const RbtString& strName, const Config& config);
     virtual ~RbtRandPopTransform();
 
     ////////////////////////////////////////
@@ -60,9 +68,7 @@ class RbtRandPopTransform: public RbtBaseBiMolTransform {
     //////////////
     RbtChromElementPtr m_chrom;
 
-    // Transform parameters
-    RbtInt population_size;
-    RbtBool scale_chromosome_length;
+    const Config config;
 };
 
 // Useful typedefs

--- a/include/RbtRandPopTransform.h
+++ b/include/RbtRandPopTransform.h
@@ -24,14 +24,11 @@ class RbtRandPopTransform: public RbtBaseBiMolTransform {
     static RbtString _SCALE_CHROM_LENGTH;
 
     struct Config {
-      RbtInt population_size;
-      RbtBool scale_chromosome_length;
+      RbtInt population_size {50};
+      RbtBool scale_chromosome_length {true};
     };
 
-    static constexpr Config DEFAULT_CONFIG {
-      .population_size = 50,
-      .scale_chromosome_length = true,
-    };
+    static const Config DEFAULT_CONFIG;
 
     RbtRandPopTransform(const RbtString& strName, const Config& config);
     virtual ~RbtRandPopTransform();

--- a/include/RbtRandPopTransform.h
+++ b/include/RbtRandPopTransform.h
@@ -59,6 +59,10 @@ class RbtRandPopTransform: public RbtBaseBiMolTransform {
     // Private data
     //////////////
     RbtChromElementPtr m_chrom;
+
+    // Transform parameters
+    RbtInt population_size;
+    RbtBool scale_chromosome_length;
 };
 
 // Useful typedefs

--- a/include/RbtRandPopTransform.h
+++ b/include/RbtRandPopTransform.h
@@ -24,8 +24,8 @@ class RbtRandPopTransform: public RbtBaseBiMolTransform {
     static RbtString _SCALE_CHROM_LENGTH;
 
     struct Config {
-      RbtInt population_size {50};
-      RbtBool scale_chromosome_length {true};
+        RbtInt population_size{50};
+        RbtBool scale_chromosome_length{true};
     };
 
     static const Config DEFAULT_CONFIG;

--- a/include/RbtSimAnnTransform.h
+++ b/include/RbtSimAnnTransform.h
@@ -59,25 +59,25 @@ class RbtSimAnnTransform: public RbtBaseBiMolTransform {
     static RbtString _PARTITION_FREQ;
     static RbtString _HISTORY_FREQ;
 
-   struct Config {
-         RbtDouble initial_temp {1000.0};
-         RbtDouble final_temp {300.0};
-         RbtInt num_blocks {25};
-         RbtInt block_length {50};
-         RbtBool scale_chromosome_length {true};
-         RbtDouble step_size {1.0}; 
-         RbtDouble min_accuracy_rate {0.25};
-         RbtDouble partition_distance {0.0};
-         RbtInt partition_frequency {0};
-         RbtInt history_frequency {0};
-   };
+    struct Config {
+        RbtDouble initial_temp{1000.0};
+        RbtDouble final_temp{300.0};
+        RbtInt num_blocks{25};
+        RbtInt block_length{50};
+        RbtBool scale_chromosome_length{true};
+        RbtDouble step_size{1.0};
+        RbtDouble min_accuracy_rate{0.25};
+        RbtDouble partition_distance{0.0};
+        RbtInt partition_frequency{0};
+        RbtInt history_frequency{0};
+    };
 
-   static const Config DEFAULT_CONFIG;
+    static const Config DEFAULT_CONFIG;
 
     ////////////////////////////////////////
     // Constructors/destructors
 
-      RbtSimAnnTransform(const RbtString& strName, const Config& config);
+    RbtSimAnnTransform(const RbtString& strName, const Config& config);
     virtual ~RbtSimAnnTransform();
 
     ////////////////////////////////////////

--- a/include/RbtSimAnnTransform.h
+++ b/include/RbtSimAnnTransform.h
@@ -62,6 +62,19 @@ class RbtSimAnnTransform: public RbtBaseBiMolTransform {
     ////////////////////////////////////////
     // Constructors/destructors
     RbtSimAnnTransform(const RbtString& strName = "SIMANN");
+      RbtSimAnnTransform(
+         const RbtString& strName,
+         RbtDouble initial_temp,
+         RbtDouble final_temp,
+         RbtInt num_blocks,
+         RbtInt block_length,
+         RbtBool scale_chromosome_length,
+         RbtDouble step_size,
+         RbtDouble min_accuracy_rate,
+         RbtDouble partition_distance,
+         RbtInt partition_frequency,
+         RbtInt history_frequency
+      );
     virtual ~RbtSimAnnTransform();
 
     ////////////////////////////////////////

--- a/include/RbtSimAnnTransform.h
+++ b/include/RbtSimAnnTransform.h
@@ -60,30 +60,19 @@ class RbtSimAnnTransform: public RbtBaseBiMolTransform {
     static RbtString _HISTORY_FREQ;
 
    struct Config {
-         RbtDouble initial_temp;
-         RbtDouble final_temp;
-         RbtInt num_blocks;
-         RbtInt block_length;
-         RbtBool scale_chromosome_length;
-         RbtDouble step_size;
-         RbtDouble min_accuracy_rate;
-         RbtDouble partition_distance;
-         RbtInt partition_frequency;
-         RbtInt history_frequency;
+         RbtDouble initial_temp {1000.0};
+         RbtDouble final_temp {300.0};
+         RbtInt num_blocks {25};
+         RbtInt block_length {50};
+         RbtBool scale_chromosome_length {true};
+         RbtDouble step_size {1.0}; 
+         RbtDouble min_accuracy_rate {0.25};
+         RbtDouble partition_distance {0.0};
+         RbtInt partition_frequency {0};
+         RbtInt history_frequency {0};
    };
 
-   static constexpr Config DEFAULT_CONFIG {
-      .initial_temp = 1000.0,
-      .final_temp = 300.0,
-      .num_blocks = 25,
-      .block_length = 50,
-      .scale_chromosome_length = true,
-      .step_size = 1.0,
-      .min_accuracy_rate = 0.25,
-      .partition_distance = 0.0,
-      .partition_frequency = 0,
-      .history_frequency = 0,
-   };
+   static const Config DEFAULT_CONFIG;
 
     ////////////////////////////////////////
     // Constructors/destructors

--- a/include/RbtSimAnnTransform.h
+++ b/include/RbtSimAnnTransform.h
@@ -100,6 +100,18 @@ class RbtSimAnnTransform: public RbtBaseBiMolTransform {
     RbtChromElementPtr m_chrom;      // Current chromosome
     RbtDoubleList m_minVector;       // Chromosome vector corresponding to overall minimum score
     RbtDoubleList m_lastGoodVector;  // Saved chromosome before each MC mutation (to allow revert)
+
+    // Transform Parameters
+    RbtDouble initial_temp;
+    RbtDouble final_temp;
+    RbtInt num_blocks;
+    RbtInt block_length;
+    RbtBool scale_chromosome_length;
+    RbtDouble step_size;
+    RbtDouble min_accuracy_rate;
+    RbtDouble partition_distance;
+    RbtInt partition_frequency;
+    RbtInt history_frequency;
 };
 
 // Useful typedefs

--- a/include/RbtSimAnnTransform.h
+++ b/include/RbtSimAnnTransform.h
@@ -87,22 +87,8 @@ class RbtSimAnnTransform: public RbtBaseBiMolTransform {
 
     ////////////////////////////////////////
     // Constructors/destructors
-    RbtSimAnnTransform(const RbtString& strName = "SIMANN");
-      RbtSimAnnTransform(
-         const RbtString& strName,
-         RbtDouble initial_temp,
-         RbtDouble final_temp,
-         RbtInt num_blocks,
-         RbtInt block_length,
-         RbtBool scale_chromosome_length,
-         RbtDouble step_size,
-         RbtDouble min_accuracy_rate,
-         RbtDouble partition_distance,
-         RbtInt partition_frequency,
-         RbtInt history_frequency
-      );
 
-      RbtSimAnnTransform(const RbtString& strName, Config config);
+      RbtSimAnnTransform(const RbtString& strName, const Config& config);
     virtual ~RbtSimAnnTransform();
 
     ////////////////////////////////////////

--- a/include/RbtSimAnnTransform.h
+++ b/include/RbtSimAnnTransform.h
@@ -59,6 +59,32 @@ class RbtSimAnnTransform: public RbtBaseBiMolTransform {
     static RbtString _PARTITION_FREQ;
     static RbtString _HISTORY_FREQ;
 
+   struct Config {
+         RbtDouble initial_temp;
+         RbtDouble final_temp;
+         RbtInt num_blocks;
+         RbtInt block_length;
+         RbtBool scale_chromosome_length;
+         RbtDouble step_size;
+         RbtDouble min_accuracy_rate;
+         RbtDouble partition_distance;
+         RbtInt partition_frequency;
+         RbtInt history_frequency;
+   };
+
+   static constexpr Config DEFAULT_CONFIG {
+      .initial_temp = 1000.0,
+      .final_temp = 300.0,
+      .num_blocks = 25,
+      .block_length = 50,
+      .scale_chromosome_length = true,
+      .step_size = 1.0,
+      .min_accuracy_rate = 0.25,
+      .partition_distance = 0.0,
+      .partition_frequency = 0,
+      .history_frequency = 0,
+   };
+
     ////////////////////////////////////////
     // Constructors/destructors
     RbtSimAnnTransform(const RbtString& strName = "SIMANN");
@@ -75,6 +101,8 @@ class RbtSimAnnTransform: public RbtBaseBiMolTransform {
          RbtInt partition_frequency,
          RbtInt history_frequency
       );
+
+      RbtSimAnnTransform(const RbtString& strName, Config config);
     virtual ~RbtSimAnnTransform();
 
     ////////////////////////////////////////
@@ -114,17 +142,7 @@ class RbtSimAnnTransform: public RbtBaseBiMolTransform {
     RbtDoubleList m_minVector;       // Chromosome vector corresponding to overall minimum score
     RbtDoubleList m_lastGoodVector;  // Saved chromosome before each MC mutation (to allow revert)
 
-    // Transform Parameters
-    RbtDouble initial_temp;
-    RbtDouble final_temp;
-    RbtInt num_blocks;
-    RbtInt block_length;
-    RbtBool scale_chromosome_length;
-    RbtDouble step_size;
-    RbtDouble min_accuracy_rate;
-    RbtDouble partition_distance;
-    RbtInt partition_frequency;
-    RbtInt history_frequency;
+    const Config config;
 };
 
 // Useful typedefs

--- a/include/RbtSimplexTransform.h
+++ b/include/RbtSimplexTransform.h
@@ -66,6 +66,14 @@ class RbtSimplexTransform: public RbtBaseBiMolTransform {
     // Private data
     //////////////
     RbtChromElementPtr m_chrom;
+
+    // Transform parameters
+    RbtInt max_calls;
+    RbtInt num_cycles;
+    RbtDouble stopping_step_length;
+    RbtDouble convergence_threshold;
+    RbtDouble step_size;
+    RbtDouble partition_distribution;
 };
 
 // Useful typedefs

--- a/include/RbtSimplexTransform.h
+++ b/include/RbtSimplexTransform.h
@@ -31,9 +31,25 @@ class RbtSimplexTransform: public RbtBaseBiMolTransform {
     // between cycles
     static RbtString _CONVERGENCE;
 
-    ////////////////////////////////////////
-    // Constructors/destructors
-    RbtSimplexTransform(const RbtString& strName = "SIMPLEX");
+    struct Config {
+      RbtInt max_calls;
+      RbtInt num_cycles;
+      RbtDouble stopping_step_length;
+      RbtDouble convergence_threshold;
+      RbtDouble step_size;
+      RbtDouble partition_distribution;
+    };
+
+    static constexpr Config DEFAULT_CONFIG {
+      .max_calls = 200,
+      .num_cycles = 5,
+      .stopping_step_length = 10e-4,
+      .convergence_threshold = 0.001,
+      .step_size = 0.1,
+      .partition_distribution = 0.0
+    };
+
+    RbtSimplexTransform(const RbtString& strName, const Config& config);
     virtual ~RbtSimplexTransform();
 
     ////////////////////////////////////////
@@ -67,13 +83,7 @@ class RbtSimplexTransform: public RbtBaseBiMolTransform {
     //////////////
     RbtChromElementPtr m_chrom;
 
-    // Transform parameters
-    RbtInt max_calls;
-    RbtInt num_cycles;
-    RbtDouble stopping_step_length;
-    RbtDouble convergence_threshold;
-    RbtDouble step_size;
-    RbtDouble partition_distribution;
+    const Config config;
 };
 
 // Useful typedefs

--- a/include/RbtSimplexTransform.h
+++ b/include/RbtSimplexTransform.h
@@ -32,22 +32,15 @@ class RbtSimplexTransform: public RbtBaseBiMolTransform {
     static RbtString _CONVERGENCE;
 
     struct Config {
-      RbtInt max_calls;
-      RbtInt num_cycles;
-      RbtDouble stopping_step_length;
-      RbtDouble convergence_threshold;
-      RbtDouble step_size;
-      RbtDouble partition_distribution;
+      RbtInt max_calls {200};
+      RbtInt num_cycles {5};
+      RbtDouble stopping_step_length {10e-4};
+      RbtDouble convergence_threshold {0.001};
+      RbtDouble step_size {0.1};
+      RbtDouble partition_distribution {0.0};
     };
 
-    static constexpr Config DEFAULT_CONFIG {
-      .max_calls = 200,
-      .num_cycles = 5,
-      .stopping_step_length = 10e-4,
-      .convergence_threshold = 0.001,
-      .step_size = 0.1,
-      .partition_distribution = 0.0
-    };
+    static const Config DEFAULT_CONFIG;
 
     RbtSimplexTransform(const RbtString& strName, const Config& config);
     virtual ~RbtSimplexTransform();

--- a/include/RbtSimplexTransform.h
+++ b/include/RbtSimplexTransform.h
@@ -32,12 +32,12 @@ class RbtSimplexTransform: public RbtBaseBiMolTransform {
     static RbtString _CONVERGENCE;
 
     struct Config {
-      RbtInt max_calls {200};
-      RbtInt num_cycles {5};
-      RbtDouble stopping_step_length {10e-4};
-      RbtDouble convergence_threshold {0.001};
-      RbtDouble step_size {0.1};
-      RbtDouble partition_distribution {0.0};
+        RbtInt max_calls{200};
+        RbtInt num_cycles{5};
+        RbtDouble stopping_step_length{10e-4};
+        RbtDouble convergence_threshold{0.001};
+        RbtDouble step_size{0.1};
+        RbtDouble partition_distribution{0.0};
     };
 
     static const Config DEFAULT_CONFIG;

--- a/include/RbtTransformFactory.h
+++ b/include/RbtTransformFactory.h
@@ -37,10 +37,6 @@ class RbtTransformFactory {
     // Public methods
     ////////////////
 
-    // Creates a single transform object of type strTransformClass, and name strName
-    // e.g. strTransformClass = RbtSimAnnTransform
-    virtual RbtBaseTransform* Create(const RbtString& strTransformClass, const RbtString& strName);
-
     // Creates an aggregate transform from a parameter file source
     // Each component transform is in a named section, which should minimally contain a TRANSFORM parameter
     // whose value is the class name to instantiate

--- a/include/RbtTransformFactory.h
+++ b/include/RbtTransformFactory.h
@@ -60,10 +60,9 @@ class RbtTransformFactory {
     // Private methods
     /////////////////
 
-    RbtTransformFactory(const RbtTransformFactory&);  // Copy constructor disabled by default
+    RbtTransformFactory(const RbtTransformFactory&);             // Copy constructor disabled by default
     RbtTransformFactory& operator=(const RbtTransformFactory&);  // Copy assignment disabled by default
-   RbtBaseTransform* MakeTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
-
+    RbtBaseTransform* MakeTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 
  protected:
     ////////////////////////////////////////

--- a/include/RbtTransformFactory.h
+++ b/include/RbtTransformFactory.h
@@ -68,6 +68,9 @@ class RbtTransformFactory {
 
     RbtTransformFactory& operator=(const RbtTransformFactory&);  // Copy assignment disabled by default
 
+   void AddTransformToAggFromFile(RbtTransformAgg* aggPtr, RbtParameterFileSourcePtr paramsPtr, const RbtString& kind, const RbtString& name);
+
+
  protected:
     ////////////////////////////////////////
     // Protected data

--- a/include/RbtTransformFactory.h
+++ b/include/RbtTransformFactory.h
@@ -61,10 +61,7 @@ class RbtTransformFactory {
     /////////////////
 
     RbtTransformFactory(const RbtTransformFactory&);  // Copy constructor disabled by default
-
     RbtTransformFactory& operator=(const RbtTransformFactory&);  // Copy assignment disabled by default
-
-   void AddTransformToAggFromFile(RbtTransformAgg* aggPtr, RbtParameterFileSourcePtr paramsPtr, const RbtString& kind, const RbtString& name);
    RbtBaseTransform* MakeTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 
 

--- a/include/RbtTransformFactory.h
+++ b/include/RbtTransformFactory.h
@@ -65,6 +65,7 @@ class RbtTransformFactory {
     RbtTransformFactory& operator=(const RbtTransformFactory&);  // Copy assignment disabled by default
 
    void AddTransformToAggFromFile(RbtTransformAgg* aggPtr, RbtParameterFileSourcePtr paramsPtr, const RbtString& kind, const RbtString& name);
+   RbtBaseTransform* MakeTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 
 
  protected:

--- a/src/lib/RbtAlignTransform.cxx
+++ b/src/lib/RbtAlignTransform.cxx
@@ -21,6 +21,8 @@ RbtString RbtAlignTransform::_CT("RbtAlignTransform");
 RbtString RbtAlignTransform::_COM("COM");
 RbtString RbtAlignTransform::_AXES("AXES");
 
+const RbtAlignTransform::Config RbtAlignTransform::DEFAULT_CONFIG{};  // Empty initializer to fall back to default values
+
 RbtAlignTransform::RbtAlignTransform(const RbtString& strName, const Config& config):
     RbtBaseBiMolTransform(_CT, strName),
     m_rand(Rbt::GetRbtRand()),

--- a/src/lib/RbtAlignTransform.cxx
+++ b/src/lib/RbtAlignTransform.cxx
@@ -104,6 +104,9 @@ void RbtAlignTransform::Execute() {
             if (iTrace > 1) cout << "Translating ligand COM to active site COM: " << prAxes.com << endl;
             spLigand->SetCenterOfMass(prAxes.com);
             break;
+        default:
+            throw RbtBadArgument(_WHERE_, "Bad ligand center of mass placement strategy");
+            break;
     }
 
     switch (config.axes_alignment_strategy) {
@@ -133,6 +136,9 @@ void RbtAlignTransform::Execute() {
                 spLigand->Rotate(prAxes.axis3, 180.0, prAxes.com);
                 if (iTrace > 1) cout << "180 deg rotation around PA#3" << endl;
             }
+            break;
+        default:
+            throw RbtBadArgument(_WHERE_, "Bad ligand axes alignment strategy");
             break;
     }
 }

--- a/src/lib/RbtAlignTransform.cxx
+++ b/src/lib/RbtAlignTransform.cxx
@@ -21,14 +21,14 @@ RbtString RbtAlignTransform::_CT("RbtAlignTransform");
 RbtString RbtAlignTransform::_COM("COM");
 RbtString RbtAlignTransform::_AXES("AXES");
 
-const RbtAlignTransform::Config RbtAlignTransform::DEFAULT_CONFIG{};  // Empty initializer to fall back to default values
+const RbtAlignTransform::Config
+    RbtAlignTransform::DEFAULT_CONFIG{};  // Empty initializer to fall back to default values
 
 RbtAlignTransform::RbtAlignTransform(const RbtString& strName, const Config& config):
     RbtBaseBiMolTransform(_CT, strName),
     m_rand(Rbt::GetRbtRand()),
     m_totalSize(0),
-    config{config}
-{
+    config{config} {
 #ifdef _DEBUG
     cout << _CT << " parameterised constructor" << endl;
 #endif  //_DEBUG
@@ -89,49 +89,50 @@ void RbtAlignTransform::Execute() {
     const RbtPrincipalAxes& prAxes = spCavity->GetPrincipalAxes();
 
     switch (config.center_of_mass_placement_strategy) {
-    case COM_RANDOM:
-        if (!coordList.empty()) {
-            RbtInt iRand = m_rand.GetRandomInt(coordList.size());
-            RbtCoord asCavityCoord = coordList[iRand];
-            if (iTrace > 1) {
-                cout << "Translating ligand COM to active site coord #" << iRand << ": " << asCavityCoord << endl;
+        case COM_RANDOM:
+            if (!coordList.empty()) {
+                RbtInt iRand = m_rand.GetRandomInt(coordList.size());
+                RbtCoord asCavityCoord = coordList[iRand];
+                if (iTrace > 1) {
+                    cout << "Translating ligand COM to active site coord #" << iRand << ": " << asCavityCoord << endl;
+                }
+                // Translate the ligand center of mass to the selected coord
+                spLigand->SetCenterOfMass(asCavityCoord);
             }
-            // Translate the ligand center of mass to the selected coord
-            spLigand->SetCenterOfMass(asCavityCoord); 
-        }
-        break;
-    case COM_ALIGN:
-        if (iTrace > 1) cout << "Translating ligand COM to active site COM: " << prAxes.com << endl;
-        spLigand->SetCenterOfMass(prAxes.com);
-        break;
+            break;
+        case COM_ALIGN:
+            if (iTrace > 1) cout << "Translating ligand COM to active site COM: " << prAxes.com << endl;
+            spLigand->SetCenterOfMass(prAxes.com);
+            break;
     }
 
     switch (config.axes_alignment_strategy) {
-    case AXES_RANDOM:
-    {   // Braces to prevent compiler complains due to variables initialized inside this case
+        case AXES_RANDOM:
+            {  // Braces to prevent compiler complains due to variables initialized inside this case
 
-        RbtDouble thetaDeg = 180.0 * m_rand.GetRandom01();
-        RbtCoord axis = m_rand.GetRandomUnitVector();
-        if (iTrace > 1) cout << "Rotating ligand by " << thetaDeg << " deg around axis=" << axis << " through COM" << endl;
-        spLigand->Rotate(axis, thetaDeg);
-        break;
-    }
-    case AXES_ALIGN:
-        spLigand->AlignPrincipalAxes(prAxes, false);  // false = don't translate COM as we've already done it above
-        if (iTrace > 1) cout << "Aligning ligand principal axes with active site principal axes" << endl;
-        // Make random 180 deg rotations around each of the principal axes
-        if (m_rand.GetRandom01() < 0.5) {
-            spLigand->Rotate(prAxes.axis1, 180.0, prAxes.com);
-            if (iTrace > 1) cout << "180 deg rotation around PA#1" << endl;
-        }
-        if (m_rand.GetRandom01() < 0.5) {
-            spLigand->Rotate(prAxes.axis2, 180.0, prAxes.com);
-            if (iTrace > 1) cout << "180 deg rotation around PA#2" << endl;
-        }
-        if (m_rand.GetRandom01() < 0.5) {
-            spLigand->Rotate(prAxes.axis3, 180.0, prAxes.com);
-            if (iTrace > 1) cout << "180 deg rotation around PA#3" << endl;
-        }
-        break;
+                RbtDouble thetaDeg = 180.0 * m_rand.GetRandom01();
+                RbtCoord axis = m_rand.GetRandomUnitVector();
+                if (iTrace > 1)
+                    cout << "Rotating ligand by " << thetaDeg << " deg around axis=" << axis << " through COM" << endl;
+                spLigand->Rotate(axis, thetaDeg);
+                break;
+            }
+        case AXES_ALIGN:
+            spLigand->AlignPrincipalAxes(prAxes, false);  // false = don't translate COM as we've already done it above
+            if (iTrace > 1) cout << "Aligning ligand principal axes with active site principal axes" << endl;
+            // Make random 180 deg rotations around each of the principal axes
+            if (m_rand.GetRandom01() < 0.5) {
+                spLigand->Rotate(prAxes.axis1, 180.0, prAxes.com);
+                if (iTrace > 1) cout << "180 deg rotation around PA#1" << endl;
+            }
+            if (m_rand.GetRandom01() < 0.5) {
+                spLigand->Rotate(prAxes.axis2, 180.0, prAxes.com);
+                if (iTrace > 1) cout << "180 deg rotation around PA#2" << endl;
+            }
+            if (m_rand.GetRandom01() < 0.5) {
+                spLigand->Rotate(prAxes.axis3, 180.0, prAxes.com);
+                if (iTrace > 1) cout << "180 deg rotation around PA#3" << endl;
+            }
+            break;
     }
 }

--- a/src/lib/RbtAlignTransform.cxx
+++ b/src/lib/RbtAlignTransform.cxx
@@ -21,15 +21,12 @@ RbtString RbtAlignTransform::_CT("RbtAlignTransform");
 RbtString RbtAlignTransform::_COM("COM");
 RbtString RbtAlignTransform::_AXES("AXES");
 
-////////////////////////////////////////
-// Constructors/destructors
-RbtAlignTransform::RbtAlignTransform(const RbtString& strName):
+RbtAlignTransform::RbtAlignTransform(const RbtString& strName, const Config& config):
     RbtBaseBiMolTransform(_CT, strName),
     m_rand(Rbt::GetRbtRand()),
-    m_totalSize(0) {
-    // Add parameters
-    AddParameter(_COM, "ALIGN");
-    AddParameter(_AXES, "ALIGN");
+    m_totalSize(0),
+    config{config}
+{
 #ifdef _DEBUG
     cout << _CT << " parameterised constructor" << endl;
 #endif  //_DEBUG

--- a/src/lib/RbtGATransform.cxx
+++ b/src/lib/RbtGATransform.cxx
@@ -30,6 +30,8 @@ RbtString RbtGATransform::_NCYCLES("NCYCLES");
 RbtString RbtGATransform::_NCONVERGENCE("NCONVERGENCE");
 RbtString RbtGATransform::_HISTORY_FREQ("HISTORY_FREQ");
 
+const RbtGATransform::Config RbtGATransform::DEFAULT_CONFIG {};  // Empty initializer to fall back to default values
+
 RbtGATransform::RbtGATransform(const RbtString& strName, const Config& config):
     RbtBaseBiMolTransform(_CT, strName),
     m_rand(Rbt::GetRbtRand()),

--- a/src/lib/RbtGATransform.cxx
+++ b/src/lib/RbtGATransform.cxx
@@ -30,13 +30,12 @@ RbtString RbtGATransform::_NCYCLES("NCYCLES");
 RbtString RbtGATransform::_NCONVERGENCE("NCONVERGENCE");
 RbtString RbtGATransform::_HISTORY_FREQ("HISTORY_FREQ");
 
-const RbtGATransform::Config RbtGATransform::DEFAULT_CONFIG {};  // Empty initializer to fall back to default values
+const RbtGATransform::Config RbtGATransform::DEFAULT_CONFIG{};  // Empty initializer to fall back to default values
 
 RbtGATransform::RbtGATransform(const RbtString& strName, const Config& config):
     RbtBaseBiMolTransform(_CT, strName),
     m_rand(Rbt::GetRbtRand()),
-    config{config}
-{
+    config{config} {
     _RBTOBJECTCOUNTER_CONSTR_(_CT);
 }
 

--- a/src/lib/RbtParameterFileSource.cxx
+++ b/src/lib/RbtParameterFileSource.cxx
@@ -85,6 +85,16 @@ RbtString RbtParameterFileSource::GetParameterValueAsString(const RbtString& str
         throw RbtFileMissingParameter(_WHERE_, strFullParamName + " parameter not found in " + GetFileName());
 }
 
+RbtVariant RbtParameterFileSource::GetParameterValueAsVariant(const RbtString& strParamName) {
+    Parse();
+    RbtString strFullParamName = GetFullParameterName(strParamName);
+    RbtStringVariantMapConstIter iter = m_paramsMap.find(strFullParamName);
+    if (iter != m_paramsMap.end())
+        return (*iter).second;
+    else
+        throw RbtFileMissingParameter(_WHERE_, strFullParamName + " parameter not found in " + GetFileName());
+}
+
 // DM 11 Feb 1999 Check if parameter is present
 RbtBool RbtParameterFileSource::isParameterPresent(const RbtString& strParamName) {
     Parse();

--- a/src/lib/RbtRandLigTransform.cxx
+++ b/src/lib/RbtRandLigTransform.cxx
@@ -17,13 +17,11 @@ RbtString RbtRandLigTransform::_CT("RbtRandLigTransform");
 // Parameter names
 RbtString RbtRandLigTransform::_TORS_STEP("TORS_STEP");
 
-////////////////////////////////////////
-// Constructors/destructors
-RbtRandLigTransform::RbtRandLigTransform(const RbtString& strName):
+RbtRandLigTransform::RbtRandLigTransform(const RbtString& strName, const Config& config):
     RbtBaseUniMolTransform(_CT, strName),
-    m_rand(Rbt::GetRbtRand()) {
-    // Add parameters
-    AddParameter(_TORS_STEP, 180);
+    m_rand(Rbt::GetRbtRand()),
+    config{config}
+{
 #ifdef _DEBUG
     cout << _CT << " parameterised constructor" << endl;
 #endif  //_DEBUG
@@ -56,9 +54,8 @@ void RbtRandLigTransform::SetupTransform() {
 void RbtRandLigTransform::Execute() {
     RbtModelPtr spLigand = GetLigand();
     if (spLigand.Null()) return;
-    RbtDouble torsStep = GetParameter(_TORS_STEP);
-    for (RbtBondListIter iter = m_rotableBonds.begin(); iter != m_rotableBonds.end(); iter++) {
-        RbtDouble thetaDeg = 2.0 * torsStep * m_rand.GetRandom01() - torsStep;
-        spLigand->RotateBond(*iter, thetaDeg, false);
+    for (auto& rotable_bond : m_rotableBonds) {
+        RbtDouble thetaDeg = 2.0 * config.torsion_step * m_rand.GetRandom01() - config.torsion_step;
+        spLigand->RotateBond(rotable_bond, thetaDeg, false);
     }
 }

--- a/src/lib/RbtRandLigTransform.cxx
+++ b/src/lib/RbtRandLigTransform.cxx
@@ -17,13 +17,13 @@ RbtString RbtRandLigTransform::_CT("RbtRandLigTransform");
 // Parameter names
 RbtString RbtRandLigTransform::_TORS_STEP("TORS_STEP");
 
-const RbtRandLigTransform::Config RbtRandLigTransform::DEFAULT_CONFIG {};  // Empty initializer to fall back to default values
+const RbtRandLigTransform::Config
+    RbtRandLigTransform::DEFAULT_CONFIG{};  // Empty initializer to fall back to default values
 
 RbtRandLigTransform::RbtRandLigTransform(const RbtString& strName, const Config& config):
     RbtBaseUniMolTransform(_CT, strName),
     m_rand(Rbt::GetRbtRand()),
-    config{config}
-{
+    config{config} {
 #ifdef _DEBUG
     cout << _CT << " parameterised constructor" << endl;
 #endif  //_DEBUG
@@ -56,7 +56,7 @@ void RbtRandLigTransform::SetupTransform() {
 void RbtRandLigTransform::Execute() {
     RbtModelPtr spLigand = GetLigand();
     if (spLigand.Null()) return;
-    for (auto& rotable_bond : m_rotableBonds) {
+    for (auto& rotable_bond: m_rotableBonds) {
         RbtDouble thetaDeg = 2.0 * config.torsion_step * m_rand.GetRandom01() - config.torsion_step;
         spLigand->RotateBond(rotable_bond, thetaDeg, false);
     }

--- a/src/lib/RbtRandLigTransform.cxx
+++ b/src/lib/RbtRandLigTransform.cxx
@@ -17,6 +17,8 @@ RbtString RbtRandLigTransform::_CT("RbtRandLigTransform");
 // Parameter names
 RbtString RbtRandLigTransform::_TORS_STEP("TORS_STEP");
 
+const RbtRandLigTransform::Config RbtRandLigTransform::DEFAULT_CONFIG {};  // Empty initializer to fall back to default values
+
 RbtRandLigTransform::RbtRandLigTransform(const RbtString& strName, const Config& config):
     RbtBaseUniMolTransform(_CT, strName),
     m_rand(Rbt::GetRbtRand()),

--- a/src/lib/RbtRandPopTransform.cxx
+++ b/src/lib/RbtRandPopTransform.cxx
@@ -20,9 +20,10 @@ RbtString RbtRandPopTransform::_CT("RbtRandPopTransform");
 RbtString RbtRandPopTransform::_POP_SIZE("POP_SIZE");
 RbtString RbtRandPopTransform::_SCALE_CHROM_LENGTH("SCALE_CHROM_LENGTH");
 
-RbtRandPopTransform::RbtRandPopTransform(const RbtString& strName): RbtBaseBiMolTransform(_CT, strName) {
-    AddParameter(_POP_SIZE, 50);
-    AddParameter(_SCALE_CHROM_LENGTH, true);
+RbtRandPopTransform::RbtRandPopTransform(const RbtString& strName, const Config& config):
+    RbtBaseBiMolTransform(_CT, strName),
+    config{config}
+{
     _RBTOBJECTCOUNTER_CONSTR_(_CT);
 }
 
@@ -55,16 +56,13 @@ void RbtRandPopTransform::Execute() {
     if (pSF == NULL) {
         return;
     }
-    RbtInt popSize = GetParameter(_POP_SIZE);
-    RbtBool bScale = GetParameter(_SCALE_CHROM_LENGTH);
-    if (bScale) {
+    RbtInt population_size = config.population_size;
+    if (config.scale_chromosome_length) {
         RbtInt chromLength = m_chrom->GetLength();
-        popSize *= chromLength;
+        population_size *= chromLength;
     }
-    if (GetTrace() > 3) {
-        cout << _CT << ": popSize=" << popSize << endl;
-    }
-    RbtPopulationPtr pop = new RbtPopulation(m_chrom, popSize, pSF);
+    if (GetTrace() > 3) cout << _CT << ": popSize=" << population_size << endl;
+    RbtPopulationPtr pop = new RbtPopulation(m_chrom, population_size, pSF);
     pop->Best()->GetChrom()->SyncToModel();
     GetWorkSpace()->SetPopulation(pop);
 }

--- a/src/lib/RbtRandPopTransform.cxx
+++ b/src/lib/RbtRandPopTransform.cxx
@@ -20,12 +20,12 @@ RbtString RbtRandPopTransform::_CT("RbtRandPopTransform");
 RbtString RbtRandPopTransform::_POP_SIZE("POP_SIZE");
 RbtString RbtRandPopTransform::_SCALE_CHROM_LENGTH("SCALE_CHROM_LENGTH");
 
-const RbtRandPopTransform::Config RbtRandPopTransform::DEFAULT_CONFIG {};  // Empty initializer to fall back to default values
+const RbtRandPopTransform::Config
+    RbtRandPopTransform::DEFAULT_CONFIG{};  // Empty initializer to fall back to default values
 
 RbtRandPopTransform::RbtRandPopTransform(const RbtString& strName, const Config& config):
     RbtBaseBiMolTransform(_CT, strName),
-    config{config}
-{
+    config{config} {
     _RBTOBJECTCOUNTER_CONSTR_(_CT);
 }
 

--- a/src/lib/RbtRandPopTransform.cxx
+++ b/src/lib/RbtRandPopTransform.cxx
@@ -20,6 +20,8 @@ RbtString RbtRandPopTransform::_CT("RbtRandPopTransform");
 RbtString RbtRandPopTransform::_POP_SIZE("POP_SIZE");
 RbtString RbtRandPopTransform::_SCALE_CHROM_LENGTH("SCALE_CHROM_LENGTH");
 
+const RbtRandPopTransform::Config RbtRandPopTransform::DEFAULT_CONFIG {};  // Empty initializer to fall back to default values
+
 RbtRandPopTransform::RbtRandPopTransform(const RbtString& strName, const Config& config):
     RbtBaseBiMolTransform(_CT, strName),
     config{config}

--- a/src/lib/RbtSimAnnTransform.cxx
+++ b/src/lib/RbtSimAnnTransform.cxx
@@ -66,7 +66,8 @@ RbtString RbtSimAnnTransform::_PARTITION_DIST("PARTITION_DIST");
 RbtString RbtSimAnnTransform::_PARTITION_FREQ("PARTITION_FREQ");
 RbtString RbtSimAnnTransform::_HISTORY_FREQ("HISTORY_FREQ");
 
-const RbtSimAnnTransform::Config RbtSimAnnTransform::DEFAULT_CONFIG{};  // Empty initializer to fall back to default values
+const RbtSimAnnTransform::Config
+    RbtSimAnnTransform::DEFAULT_CONFIG{};  // Empty initializer to fall back to default values
 
 RbtSimAnnTransform::RbtSimAnnTransform(const RbtString& strName, const Config& config):
     RbtBaseBiMolTransform(_CT, strName),
@@ -130,8 +131,7 @@ void RbtSimAnnTransform::Execute() {
         RbtInt chromLength = m_chrom->GetLength();
         block_length *= chromLength;
     }
-    if (iTrace > 0)
-        cout << _CT << ": Block length = " << block_length << endl;
+    if (iTrace > 0) cout << _CT << ": Block length = " << block_length << endl;
 
     // Send the partitioning request separately based on the current partition distance
     // If partDist is zero, the partitioning automatically gets removed
@@ -165,7 +165,8 @@ void RbtSimAnnTransform::Execute() {
     // DM 15 Feb 1999 - don't initialise the Monte Carlo stats each block
     // if we are doing a constant temperature run
     RbtBool bInitBlock = (config.initial_temp != config.final_temp);
-    RbtDouble tFac = (config.num_blocks > 1) ? pow(config.final_temp / config.initial_temp, 1.0 / (config.num_blocks - 1)) : 1.0;
+    RbtDouble tFac =
+        (config.num_blocks > 1) ? pow(config.final_temp / config.initial_temp, 1.0 / (config.num_blocks - 1)) : 1.0;
 
     for (RbtInt iBlock = 1; iBlock <= config.num_blocks; iBlock++, initial_temp *= tFac) {
         if (bInitBlock) {
@@ -173,8 +174,8 @@ void RbtSimAnnTransform::Execute() {
         }
         MC(initial_temp, block_length, step_size);
         if (iTrace > 0) {
-            cout << setw(5) << iBlock << setw(10) << initial_temp << setw(10) << m_spStats->AccRate() << setw(10) << step_size
-                 << setw(10) << m_spStats->_blockInitial << setw(10) << m_spStats->_blockFinal << setw(10)
+            cout << setw(5) << iBlock << setw(10) << initial_temp << setw(10) << m_spStats->AccRate() << setw(10)
+                 << step_size << setw(10) << m_spStats->_blockInitial << setw(10) << m_spStats->_blockFinal << setw(10)
                  << m_spStats->Mean() << setw(10) << sqrt(m_spStats->Variance()) << setw(10) << m_spStats->_blockMin
                  << setw(10) << m_spStats->_blockMax << endl;
         }

--- a/src/lib/RbtSimAnnTransform.cxx
+++ b/src/lib/RbtSimAnnTransform.cxx
@@ -66,6 +66,8 @@ RbtString RbtSimAnnTransform::_PARTITION_DIST("PARTITION_DIST");
 RbtString RbtSimAnnTransform::_PARTITION_FREQ("PARTITION_FREQ");
 RbtString RbtSimAnnTransform::_HISTORY_FREQ("HISTORY_FREQ");
 
+const RbtSimAnnTransform::Config RbtSimAnnTransform::DEFAULT_CONFIG{};  // Empty initializer to fall back to default values
+
 RbtSimAnnTransform::RbtSimAnnTransform(const RbtString& strName, const Config& config):
     RbtBaseBiMolTransform(_CT, strName),
     m_rand(Rbt::GetRbtRand()),

--- a/src/lib/RbtSimAnnTransform.cxx
+++ b/src/lib/RbtSimAnnTransform.cxx
@@ -66,7 +66,7 @@ RbtString RbtSimAnnTransform::_PARTITION_DIST("PARTITION_DIST");
 RbtString RbtSimAnnTransform::_PARTITION_FREQ("PARTITION_FREQ");
 RbtString RbtSimAnnTransform::_HISTORY_FREQ("HISTORY_FREQ");
 
-RbtSimAnnTransform::RbtSimAnnTransform(const RbtString& strName, Config config):
+RbtSimAnnTransform::RbtSimAnnTransform(const RbtString& strName, const Config& config):
     RbtBaseBiMolTransform(_CT, strName),
     m_rand(Rbt::GetRbtRand()),
     config{config}  // For now simply copy the config structure.

--- a/src/lib/RbtSimAnnTransform.cxx
+++ b/src/lib/RbtSimAnnTransform.cxx
@@ -89,6 +89,38 @@ RbtSimAnnTransform::RbtSimAnnTransform(const RbtString& strName):
     _RBTOBJECTCOUNTER_CONSTR_(_CT);
 }
 
+RbtSimAnnTransform::RbtSimAnnTransform(
+    const RbtString& strName,
+    RbtDouble initial_temp,
+    RbtDouble final_temp,
+    RbtInt num_blocks,
+    RbtInt block_length,
+    RbtBool scale_chromosome_length,
+    RbtDouble step_size,
+    RbtDouble min_accuracy_rate,
+    RbtDouble partition_distance,
+    RbtInt partition_frequency,
+    RbtInt history_frequency
+):
+    RbtBaseBiMolTransform(_CT, strName),
+    initial_temp{initial_temp},
+    final_temp{final_temp},
+    num_blocks{num_blocks},
+    block_length{block_length},
+    scale_chromosome_length{scale_chromosome_length},
+    step_size{step_size},
+    min_accuracy_rate{min_accuracy_rate},
+    partition_distance{partition_distance},
+    partition_frequency{partition_frequency},
+    history_frequency{history_frequency},
+    m_rand(Rbt::GetRbtRand()) {
+    m_spStats = RbtMCStatsPtr(new RbtMCStats());
+#ifdef _DEBUG
+    cout << _CT << " parameterised constructor" << endl;
+#endif  //_DEBUG
+    _RBTOBJECTCOUNTER_CONSTR_(_CT);
+}
+
 RbtSimAnnTransform::~RbtSimAnnTransform() {
 #ifdef _DEBUG
     cout << _CT << " destructor" << endl;

--- a/src/lib/RbtSimplexTransform.cxx
+++ b/src/lib/RbtSimplexTransform.cxx
@@ -30,19 +30,14 @@ RbtString RbtSimplexTransform::_PARTITION_DIST("PARTITION_DIST");
 RbtString RbtSimplexTransform::_STEP_SIZE("STEP_SIZE");
 RbtString RbtSimplexTransform::_CONVERGENCE("CONVERGENCE");
 
-////////////////////////////////////////
-// Constructors/destructors
-RbtSimplexTransform::RbtSimplexTransform(const RbtString& strName): RbtBaseBiMolTransform(_CT, strName) {
-    AddParameter(_MAX_CALLS, 200);
-    AddParameter(_NCYCLES, 5);
-    AddParameter(_STOPPING_STEP_LENGTH, 10e-4);
-    AddParameter(_PARTITION_DIST, 0.0);
-    AddParameter(_STEP_SIZE, 0.1);
-    AddParameter(_CONVERGENCE, 0.001);
+RbtSimplexTransform::RbtSimplexTransform(const RbtString& strName, const Config& config):
+    RbtBaseBiMolTransform(_CT, strName),
+    config{config}
+{
 #ifdef _DEBUG
     cout << _CT << " parameterised constructor" << endl;
 #endif  //_DEBUG
-    _RBTOBJECTCOUNTER_CONSTR_(_CT);
+    _RBTOBJECTCOUNTER_CONSTR_(_CT);   
 }
 
 RbtSimplexTransform::~RbtSimplexTransform() {
@@ -86,13 +81,7 @@ void RbtSimplexTransform::Execute() {
     RbtInt iTrace = GetTrace();
 
     pWorkSpace->ClearPopulation();
-    RbtInt maxcalls = GetParameter(_MAX_CALLS);
-    RbtInt ncycles = GetParameter(_NCYCLES);
-    RbtDouble stopping = GetParameter(_STOPPING_STEP_LENGTH);
-    RbtDouble convergence = GetParameter(_CONVERGENCE);
-    RbtDouble stepSize = GetParameter(_STEP_SIZE);
-    RbtDouble partDist = GetParameter(_PARTITION_DIST);
-    RbtRequestPtr spPartReq(new RbtSFPartitionRequest(partDist));
+    RbtRequestPtr spPartReq(new RbtSFPartitionRequest(config.partition_distribution));
     RbtRequestPtr spClearPartReq(new RbtSFPartitionRequest(0.0));
     pSF->HandleRequest(spPartReq);
 
@@ -104,20 +93,19 @@ void RbtSimplexTransform::Execute() {
     RbtInt nsv = sv.size();
     RbtDouble* steps = new RbtDouble[nsv];
     for (RbtInt i = 0; i < nsv; ++i) {
-        steps[i] = sv[i] * stepSize;
+        steps[i] = sv[i] * config.step_size;
     }
 
     // Set up the Simplex search object
     NMSearch* ssearch;
-    NMSearch::SetMaxCalls(maxcalls);
-    NMSearch::SetStoppingLength(stopping);
+    NMSearch::SetMaxCalls(config.max_calls);
+    NMSearch::SetStoppingLength(config.stopping_step_length);
     RbtInt calls = 0;
     RbtDouble initScore = pSF->Score();  // Current score
     RbtDouble min = initScore;
     RbtDoubleList vc;  // Vector representation of chromosome
-    RbtInt N = ncycles;
     // Energy change between cycles - initialise so as not to terminate loop immediately
-    RbtDouble delta = -convergence - 1.0;
+    RbtDouble delta = -config.convergence_threshold - 1.0;
 
     if (iTrace > 0) {
         cout.precision(3);
@@ -136,8 +124,8 @@ void RbtSimplexTransform::Execute() {
         }
     }
 
-    for (RbtInt i = 0; (i < N) && (delta < -convergence); i++) {
-        if (partDist > 0.0) {
+    for (RbtInt i = 0; (i < config.num_cycles) && (delta < -config.convergence_threshold); i++) {
+        if (config.partition_distribution > 0.0) {
             pSF->HandleRequest(spPartReq);
         }
         // Use a variable length simplex

--- a/src/lib/RbtSimplexTransform.cxx
+++ b/src/lib/RbtSimplexTransform.cxx
@@ -30,6 +30,8 @@ RbtString RbtSimplexTransform::_PARTITION_DIST("PARTITION_DIST");
 RbtString RbtSimplexTransform::_STEP_SIZE("STEP_SIZE");
 RbtString RbtSimplexTransform::_CONVERGENCE("CONVERGENCE");
 
+const RbtSimplexTransform::Config RbtSimplexTransform::DEFAULT_CONFIG {};   // Empty initializer to fall back to default values
+
 RbtSimplexTransform::RbtSimplexTransform(const RbtString& strName, const Config& config):
     RbtBaseBiMolTransform(_CT, strName),
     config{config}

--- a/src/lib/RbtSimplexTransform.cxx
+++ b/src/lib/RbtSimplexTransform.cxx
@@ -30,16 +30,16 @@ RbtString RbtSimplexTransform::_PARTITION_DIST("PARTITION_DIST");
 RbtString RbtSimplexTransform::_STEP_SIZE("STEP_SIZE");
 RbtString RbtSimplexTransform::_CONVERGENCE("CONVERGENCE");
 
-const RbtSimplexTransform::Config RbtSimplexTransform::DEFAULT_CONFIG {};   // Empty initializer to fall back to default values
+const RbtSimplexTransform::Config
+    RbtSimplexTransform::DEFAULT_CONFIG{};  // Empty initializer to fall back to default values
 
 RbtSimplexTransform::RbtSimplexTransform(const RbtString& strName, const Config& config):
     RbtBaseBiMolTransform(_CT, strName),
-    config{config}
-{
+    config{config} {
 #ifdef _DEBUG
     cout << _CT << " parameterised constructor" << endl;
 #endif  //_DEBUG
-    _RBTOBJECTCOUNTER_CONSTR_(_CT);   
+    _RBTOBJECTCOUNTER_CONSTR_(_CT);
 }
 
 RbtSimplexTransform::~RbtSimplexTransform() {

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -92,36 +92,20 @@ void RbtTransformFactory::AddTransformToAggFromFile(RbtTransformAgg* aggPtr, Rbt
     // Component transforms
     if (kind == RbtSimAnnTransform::_CT) {
         pTransform = MakeSimmulatedAnnealingTransformFromFile(paramsPtr, name);
-        aggPtr->Add(pTransform);
-        return;
     } else if (kind == RbtGATransform::_CT) {
         pTransform = MakeGeneticAlgorithmTransformFromFile(paramsPtr, name);
-        aggPtr->Add(pTransform);
-        return;
     } else if (kind == RbtAlignTransform::_CT) {
         pTransform = MakeLigandAlignTransformFromFile(paramsPtr, name);
-        aggPtr->Add(pTransform);
-        return;
     } else if (kind == RbtNullTransform::_CT) {
         pTransform = MakeNullTransformFromFile(paramsPtr, name);
-        aggPtr->Add(pTransform);
-        // Do not exit as we're using the null transform to set parameters for the score functions.
     } else if (kind == RbtRandLigTransform::_CT) {
         pTransform = MakeRandomizeLigandTransformFromFile(paramsPtr, name);
-        aggPtr->Add(pTransform);
-        return;
     } else if (kind == RbtRandPopTransform::_CT) {
         pTransform = MakeRandomizePopulationTransformFromFile(paramsPtr, name);
-        aggPtr->Add(pTransform);
-        return;
     } else if (kind == RbtSimplexTransform::_CT) {
         pTransform = MakeSimplexTransformFromFile(paramsPtr, name);
-        aggPtr->Add(pTransform);
-        return;
     } else if (kind == RbtTransformAgg::_CT) {
         pTransform = MakeAggregateTransformFromFile(paramsPtr, name);
-        aggPtr->Add(pTransform);
-        return;
     } else throw RbtBadArgument(_WHERE_, "Unknown transform: " + kind);
 
     // Set all the transform parameters from the rest of the parameters listed
@@ -129,14 +113,14 @@ void RbtTransformFactory::AddTransformToAggFromFile(RbtTransformAgg* aggPtr, Rbt
     for (RbtStringListConstIter prmIter = prmList.begin(); prmIter != prmList.end(); prmIter++) {
         // Look for scoring function request (PARAM@SF)
         // Only SetParamRequest currently supported
+        // Parameters of the individual transformers are explicitly set by their respective constructor functions
+        // So we only look for score function overrides.
         RbtStringList compList = Rbt::ConvertDelimitedStringToList(*prmIter, "@");
         if (compList.size() == 2) {
             RbtRequestPtr spReq(new RbtSFSetParamRequest(
                 compList[1], compList[0], paramsPtr->GetParameterValueAsString(*prmIter)
             ));
             pTransform->AddSFRequest(spReq);
-        } else if ((*prmIter) != _TRANSFORM) {  // Skip _TRANSFORM parameter
-            pTransform->SetParameter(*prmIter, paramsPtr->GetParameterValueAsString(*prmIter));
         }
     }
     aggPtr->Add(pTransform);

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -102,19 +102,20 @@ RbtBaseTransform* RbtTransformFactory::MakeTransformFromFile(RbtParameterFileSou
 }
 
 RbtSimAnnTransform* MakeSimmulatedAnnealingTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
-    return new RbtSimAnnTransform(
-        name,
-        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_START_T, 1000.0),
-        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_FINAL_T, 300.0),
-        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_NUM_BLOCKS, 25),
-        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_BLOCK_LENGTH, 50),
-        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_SCALE_CHROM_LENGTH, true),
-        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_STEP_SIZE, 1.0),
-        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_MIN_ACC_RATE, 0.25),
-        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_PARTITION_DIST, 0.0),
-        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_PARTITION_FREQ, 0),
-        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_HISTORY_FREQ, 0)
-    );
+    const RbtSimAnnTransform::Config& default_config = RbtSimAnnTransform::DEFAULT_CONFIG;
+    RbtSimAnnTransform::Config config {
+        .initial_temp=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_START_T, default_config.initial_temp),
+        .final_temp=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_FINAL_T, default_config.final_temp),
+        .num_blocks=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_NUM_BLOCKS, default_config.num_blocks),
+        .block_length=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_BLOCK_LENGTH, default_config.block_length),
+        .scale_chromosome_length=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_SCALE_CHROM_LENGTH, default_config.scale_chromosome_length),
+        .step_size=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_STEP_SIZE, default_config.step_size),
+        .min_accuracy_rate=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_MIN_ACC_RATE, default_config.min_accuracy_rate),
+        .partition_distance=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_PARTITION_DIST, default_config.partition_distance),
+        .partition_frequency=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_PARTITION_FREQ, default_config.partition_frequency),
+        .history_frequency=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_HISTORY_FREQ, default_config.history_frequency),
+    };
+    return new RbtSimAnnTransform(name, config);
 }
 
 RbtGATransform* MakeGeneticAlgorithmTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -30,6 +30,8 @@ RbtAlignTransform* MakeLigandAlignTransformFromFile(RbtParameterFileSourcePtr pa
 RbtNullTransform* MakeNullTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 RbtRandLigTransform* MakeRandomizeLigandTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 RbtRandPopTransform* MakeRandomizePopulationTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
+RbtSimplexTransform* MakeSimplexTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
+
 
 // Parameter name which identifies a scoring function definition
 RbtString RbtTransformFactory::_TRANSFORM("TRANSFORM");
@@ -108,9 +110,13 @@ void RbtTransformFactory::AddTransformToAggFromFile(RbtTransformAgg* aggPtr, Rbt
         aggPtr->Add(pTransform);
         return;
     } else if (kind == RbtRandPopTransform::_CT) {
-        pTransform = new RbtRandPopTransform(name);
+        pTransform = MakeRandomizePopulationTransformFromFile(paramsPtr, name);
+        aggPtr->Add(pTransform);
+        return;
     } else if (kind == RbtSimplexTransform::_CT) {
-        pTransform = new RbtSimplexTransform(name);
+        pTransform = MakeSimplexTransformFromFile(paramsPtr, name);
+        aggPtr->Add(pTransform);
+        return;
     } else if (kind == RbtTransformAgg::_CT) {
         pTransform = new RbtTransformAgg(name);
     } else throw RbtBadArgument(_WHERE_, "Unknown transform: " + kind);
@@ -189,5 +195,16 @@ RbtRandPopTransform* MakeRandomizePopulationTransformFromFile(RbtParameterFileSo
     auto transform = new RbtRandPopTransform(name);
     SetParameterIfExistsInSection(transform, paramsPtr, RbtRandPopTransform::_POP_SIZE);
     SetParameterIfExistsInSection(transform, paramsPtr, RbtRandPopTransform::_SCALE_CHROM_LENGTH);
+    return transform;
+}
+
+RbtSimplexTransform* MakeSimplexTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
+    auto transform = new RbtSimplexTransform(name);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimplexTransform::_MAX_CALLS);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimplexTransform::_NCYCLES);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimplexTransform::_STOPPING_STEP_LENGTH);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimplexTransform::_PARTITION_DIST);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimplexTransform::_STEP_SIZE);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimplexTransform::_CONVERGENCE);
     return transform;
 }

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -88,25 +88,7 @@ RbtTransformAgg* RbtTransformFactory::CreateAggFromFile(
 // Assumes that the file source is pointing to the appropriate section
 void RbtTransformFactory::AddTransformToAggFromFile(RbtTransformAgg* aggPtr, RbtParameterFileSourcePtr paramsPtr, const RbtString& kind, const RbtString& name) {
     // Create new transform according to the string value of _TRANSFORM parameter
-    RbtBaseTransform* pTransform;
-    // Component transforms
-    if (kind == RbtSimAnnTransform::_CT) {
-        pTransform = MakeSimmulatedAnnealingTransformFromFile(paramsPtr, name);
-    } else if (kind == RbtGATransform::_CT) {
-        pTransform = MakeGeneticAlgorithmTransformFromFile(paramsPtr, name);
-    } else if (kind == RbtAlignTransform::_CT) {
-        pTransform = MakeLigandAlignTransformFromFile(paramsPtr, name);
-    } else if (kind == RbtNullTransform::_CT) {
-        pTransform = MakeNullTransformFromFile(paramsPtr, name);
-    } else if (kind == RbtRandLigTransform::_CT) {
-        pTransform = MakeRandomizeLigandTransformFromFile(paramsPtr, name);
-    } else if (kind == RbtRandPopTransform::_CT) {
-        pTransform = MakeRandomizePopulationTransformFromFile(paramsPtr, name);
-    } else if (kind == RbtSimplexTransform::_CT) {
-        pTransform = MakeSimplexTransformFromFile(paramsPtr, name);
-    } else if (kind == RbtTransformAgg::_CT) {
-        pTransform = MakeAggregateTransformFromFile(paramsPtr, name);
-    } else throw RbtBadArgument(_WHERE_, "Unknown transform: " + kind);
+    RbtBaseTransform* pTransform = MakeTransformFromFile(paramsPtr, name);
 
     // Set all the transform parameters from the rest of the parameters listed
     RbtStringList prmList = paramsPtr->GetParameterList();
@@ -126,9 +108,17 @@ void RbtTransformFactory::AddTransformToAggFromFile(RbtTransformAgg* aggPtr, Rbt
     aggPtr->Add(pTransform);
 }
 
-void SetParameterIfExistsInSection(RbtBaseTransform* transform, RbtParameterFileSourcePtr paramsPtr, const RbtString& paramName) {
-    if (paramsPtr->isParameterPresent(paramName))
-        transform->SetParameter(paramName, paramsPtr->GetParameterValueAsString(paramName));
+RbtBaseTransform* RbtTransformFactory::MakeTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
+    RbtString kind(paramsPtr->GetParameterValueAsString(_TRANSFORM));   // FOrce a cast from RbtVariant to String
+    if (kind == RbtSimAnnTransform::_CT) return MakeSimmulatedAnnealingTransformFromFile(paramsPtr, name);
+    else if (kind == RbtGATransform::_CT) return MakeGeneticAlgorithmTransformFromFile(paramsPtr, name);
+    else if (kind == RbtAlignTransform::_CT) return MakeLigandAlignTransformFromFile(paramsPtr, name);
+    else if (kind == RbtNullTransform::_CT) return MakeNullTransformFromFile(paramsPtr, name);
+    else if (kind == RbtRandLigTransform::_CT) return MakeRandomizeLigandTransformFromFile(paramsPtr, name);
+    else if (kind == RbtRandPopTransform::_CT) return MakeRandomizePopulationTransformFromFile(paramsPtr, name);
+    else if (kind == RbtSimplexTransform::_CT) return MakeSimplexTransformFromFile(paramsPtr, name);
+    else if (kind == RbtTransformAgg::_CT) return MakeAggregateTransformFromFile(paramsPtr, name);
+    else throw RbtBadArgument(_WHERE_, "Unknown transform: " + kind);
 }
 
 RbtSimAnnTransform* MakeSimmulatedAnnealingTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
@@ -198,4 +188,9 @@ RbtSimplexTransform* MakeSimplexTransformFromFile(RbtParameterFileSourcePtr para
 
 RbtTransformAgg* MakeAggregateTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
     return new RbtTransformAgg(name);
+}
+
+void SetParameterIfExistsInSection(RbtBaseTransform* transform, RbtParameterFileSourcePtr paramsPtr, const RbtString& paramName) {
+    if (paramsPtr->isParameterPresent(paramName))
+        transform->SetParameter(paramName, paramsPtr->GetParameterValueAsString(paramName));
 }

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -151,9 +151,11 @@ static RbtNullTransform* MakeNullTransformFromFile(RbtParameterFileSourcePtr par
 }
 
 static RbtRandLigTransform* MakeRandomizeLigandTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
-    auto transform = new RbtRandLigTransform(name);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtRandLigTransform::_TORS_STEP);
-    return transform;
+    const RbtRandLigTransform::Config& default_config = RbtRandLigTransform::DEFAULT_CONFIG;
+    RbtRandLigTransform::Config config {
+        .torsion_step = paramsPtr->GetParamOrDefault(RbtRandLigTransform::_TORS_STEP, default_config.torsion_step),
+    };
+    return new RbtRandLigTransform(name, config);
 }
 
 static RbtRandPopTransform* MakeRandomizePopulationTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -31,6 +31,7 @@ RbtNullTransform* MakeNullTransformFromFile(RbtParameterFileSourcePtr paramsPtr,
 RbtRandLigTransform* MakeRandomizeLigandTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 RbtRandPopTransform* MakeRandomizePopulationTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 RbtSimplexTransform* MakeSimplexTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
+RbtTransformAgg* MakeAggregateTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 
 
 // Parameter name which identifies a scoring function definition
@@ -118,7 +119,9 @@ void RbtTransformFactory::AddTransformToAggFromFile(RbtTransformAgg* aggPtr, Rbt
         aggPtr->Add(pTransform);
         return;
     } else if (kind == RbtTransformAgg::_CT) {
-        pTransform = new RbtTransformAgg(name);
+        pTransform = MakeAggregateTransformFromFile(paramsPtr, name);
+        aggPtr->Add(pTransform);
+        return;
     } else throw RbtBadArgument(_WHERE_, "Unknown transform: " + kind);
 
     // Set all the transform parameters from the rest of the parameters listed
@@ -207,4 +210,8 @@ RbtSimplexTransform* MakeSimplexTransformFromFile(RbtParameterFileSourcePtr para
     SetParameterIfExistsInSection(transform, paramsPtr, RbtSimplexTransform::_STEP_SIZE);
     SetParameterIfExistsInSection(transform, paramsPtr, RbtSimplexTransform::_CONVERGENCE);
     return transform;
+}
+
+RbtTransformAgg* MakeAggregateTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
+    return new RbtTransformAgg(name);
 }

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -27,6 +27,8 @@ void SetParameterIfExistsInSection(RbtBaseTransform* transform, RbtParameterFile
 RbtSimAnnTransform* MakeSimmulatedAnnealingTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 RbtGATransform* MakeGeneticAlgorithmTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 RbtAlignTransform* MakeLigandAlignTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
+RbtNullTransform* MakeNullTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
+RbtRandLigTransform* MakeRandomizeLigandTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 
 // Parameter name which identifies a scoring function definition
 RbtString RbtTransformFactory::_TRANSFORM("TRANSFORM");
@@ -97,9 +99,13 @@ void RbtTransformFactory::AddTransformToAggFromFile(RbtTransformAgg* aggPtr, Rbt
         aggPtr->Add(pTransform);
         return;
     } else if (kind == RbtNullTransform::_CT) {
-        pTransform = new RbtNullTransform(name);
+        pTransform = MakeNullTransformFromFile(paramsPtr, name);
+        aggPtr->Add(pTransform);
+        // Do not exit as we're using the null transform to set parameters for the score functions.
     } else if (kind == RbtRandLigTransform::_CT) {
-        pTransform = new RbtRandLigTransform(name);
+        pTransform = MakeRandomizeLigandTransformFromFile(paramsPtr, name);
+        aggPtr->Add(pTransform);
+        return;
     } else if (kind == RbtRandPopTransform::_CT) {
         pTransform = new RbtRandPopTransform(name);
     } else if (kind == RbtSimplexTransform::_CT) {
@@ -164,5 +170,16 @@ RbtAlignTransform* MakeLigandAlignTransformFromFile(RbtParameterFileSourcePtr pa
     auto transform = new RbtAlignTransform(name);
     SetParameterIfExistsInSection(transform, paramsPtr, RbtAlignTransform::_COM);
     SetParameterIfExistsInSection(transform, paramsPtr, RbtAlignTransform::_AXES);
+    return transform;
+}
+
+// Doesn't have any parameters but let's create it for simmetry;
+RbtNullTransform* MakeNullTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
+    return new RbtNullTransform(name);
+}
+
+RbtRandLigTransform* MakeRandomizeLigandTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
+    auto transform = new RbtRandLigTransform(name);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtRandLigTransform::_TORS_STEP);
     return transform;
 }

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -34,22 +34,6 @@ RbtTransformFactory::~RbtTransformFactory() {}
 ////////////////////////////////////////
 // Public methods
 ////////////////
-// Creates a single transform object of type strTransformClass, and name strName
-// e.g. strTransformClass = RbtSimAnnTransform
-RbtBaseTransform* RbtTransformFactory::Create(const RbtString& strTransformClass, const RbtString& strName) {
-    // Component transforms
-    if (strTransformClass == RbtSimAnnTransform::_CT) return new RbtSimAnnTransform(strName);
-    if (strTransformClass == RbtGATransform::_CT) return new RbtGATransform(strName);
-    if (strTransformClass == RbtAlignTransform::_CT) return new RbtAlignTransform(strName);
-    if (strTransformClass == RbtNullTransform::_CT) return new RbtNullTransform(strName);
-    if (strTransformClass == RbtRandLigTransform::_CT) return new RbtRandLigTransform(strName);
-    if (strTransformClass == RbtRandPopTransform::_CT) return new RbtRandPopTransform(strName);
-    if (strTransformClass == RbtSimplexTransform::_CT) return new RbtSimplexTransform(strName);
-    // Aggregate transforms
-    if (strTransformClass == RbtTransformAgg::_CT) return new RbtTransformAgg(strName);
-
-    throw RbtBadArgument(_WHERE_, "Unknown transform " + strTransformClass);
-}
 
 void RbtTransformFactory::AddTransformToAggFromFile(RbtTransformAgg* aggPtr, RbtParameterFileSourcePtr paramsPtr, const RbtString& kind, const RbtString& name) {
     // Create new transform according to the string value of _TRANSFORM parameter

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -23,7 +23,6 @@
 #include "RbtSimplexTransform.h"
 
 
-static void SetParameterIfExistsInSection(RbtBaseTransform* transform, RbtParameterFileSourcePtr paramsPtr, const RbtString& paramName);
 static RbtSimAnnTransform* MakeSimmulatedAnnealingTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 static RbtGATransform* MakeGeneticAlgorithmTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 static RbtAlignTransform* MakeLigandAlignTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
@@ -168,23 +167,20 @@ static RbtRandPopTransform* MakeRandomizePopulationTransformFromFile(RbtParamete
 }
 
 static RbtSimplexTransform* MakeSimplexTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
-    auto transform = new RbtSimplexTransform(name);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimplexTransform::_MAX_CALLS);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimplexTransform::_NCYCLES);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimplexTransform::_STOPPING_STEP_LENGTH);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimplexTransform::_PARTITION_DIST);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimplexTransform::_STEP_SIZE);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimplexTransform::_CONVERGENCE);
-    return transform;
+    const RbtSimplexTransform::Config& default_config = RbtSimplexTransform::DEFAULT_CONFIG;
+    RbtSimplexTransform::Config config {
+        .max_calls = paramsPtr->GetParamOrDefault(RbtSimplexTransform::_MAX_CALLS, default_config.max_calls),
+        .num_cycles = paramsPtr->GetParamOrDefault(RbtSimplexTransform::_NCYCLES, default_config.num_cycles),
+        .stopping_step_length = paramsPtr->GetParamOrDefault(RbtSimplexTransform::_STOPPING_STEP_LENGTH, default_config.stopping_step_length),
+        .convergence_threshold = paramsPtr->GetParamOrDefault(RbtSimplexTransform::_CONVERGENCE, default_config.convergence_threshold),
+        .step_size = paramsPtr->GetParamOrDefault(RbtSimplexTransform::_STEP_SIZE, default_config.step_size),
+        .partition_distribution = paramsPtr->GetParamOrDefault(RbtSimplexTransform::_PARTITION_DIST, default_config.partition_distribution),
+    };
+    return new RbtSimplexTransform(name, config);
 }
 
 static RbtTransformAgg* MakeAggregateTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
     return new RbtTransformAgg(name);
-}
-
-static void SetParameterIfExistsInSection(RbtBaseTransform* transform, RbtParameterFileSourcePtr paramsPtr, const RbtString& paramName) {
-    if (paramsPtr->isParameterPresent(paramName))
-        transform->SetParameter(paramName, paramsPtr->GetParameterValueAsString(paramName));
 }
 
 static void RegisterScoreFunctionOverridesInTransform(RbtBaseTransform* transform, RbtParameterFileSourcePtr paramsPtr) {

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -26,6 +26,7 @@
 void SetParameterIfExistsInSection(RbtBaseTransform* transform, RbtParameterFileSourcePtr paramsPtr, const RbtString& paramName);
 RbtSimAnnTransform* MakeSimmulatedAnnealingTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 RbtGATransform* MakeGeneticAlgorithmTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
+RbtAlignTransform* MakeLigandAlignTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 
 // Parameter name which identifies a scoring function definition
 RbtString RbtTransformFactory::_TRANSFORM("TRANSFORM");
@@ -92,7 +93,9 @@ void RbtTransformFactory::AddTransformToAggFromFile(RbtTransformAgg* aggPtr, Rbt
         aggPtr->Add(pTransform);
         return;
     } else if (kind == RbtAlignTransform::_CT) {
-        pTransform = new RbtAlignTransform(name);
+        pTransform = MakeLigandAlignTransformFromFile(paramsPtr, name);
+        aggPtr->Add(pTransform);
+        return;
     } else if (kind == RbtNullTransform::_CT) {
         pTransform = new RbtNullTransform(name);
     } else if (kind == RbtRandLigTransform::_CT) {
@@ -154,5 +157,12 @@ RbtGATransform* MakeGeneticAlgorithmTransformFromFile(RbtParameterFileSourcePtr 
     SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_NCYCLES);
     SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_NCONVERGENCE);
     SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_HISTORY_FREQ);
+    return transform;
+}
+
+RbtAlignTransform* MakeLigandAlignTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
+    auto transform = new RbtAlignTransform(name);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtAlignTransform::_COM);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtAlignTransform::_AXES);
     return transform;
 }

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -25,6 +25,7 @@
 
 void SetParameterIfExistsInSection(RbtBaseTransform* transform, RbtParameterFileSourcePtr paramsPtr, const RbtString& paramName);
 RbtSimAnnTransform* MakeSimmulatedAnnealingTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
+RbtGATransform* MakeGeneticAlgorithmTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 
 // Parameter name which identifies a scoring function definition
 RbtString RbtTransformFactory::_TRANSFORM("TRANSFORM");
@@ -87,7 +88,9 @@ void RbtTransformFactory::AddTransformToAggFromFile(RbtTransformAgg* aggPtr, Rbt
         aggPtr->Add(pTransform);
         return;
     } else if (kind == RbtGATransform::_CT) {
-        pTransform = new RbtGATransform(name);
+        pTransform = MakeGeneticAlgorithmTransformFromFile(paramsPtr, name);
+        aggPtr->Add(pTransform);
+        return;
     } else if (kind == RbtAlignTransform::_CT) {
         pTransform = new RbtAlignTransform(name);
     } else if (kind == RbtNullTransform::_CT) {
@@ -137,5 +140,19 @@ RbtSimAnnTransform* MakeSimmulatedAnnealingTransformFromFile(RbtParameterFileSou
     SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_PARTITION_DIST);
     SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_PARTITION_FREQ);
     SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_HISTORY_FREQ);
+    return transform;
+}
+
+RbtGATransform* MakeGeneticAlgorithmTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
+    auto transform = new RbtGATransform(name);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_NEW_FRACTION);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_PCROSSOVER);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_XOVERMUT);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_CMUTATE);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_STEP_SIZE);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_EQUALITY_THRESHOLD);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_NCYCLES);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_NCONVERGENCE);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_HISTORY_FREQ);
     return transform;
 }

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -104,32 +104,34 @@ RbtBaseTransform* RbtTransformFactory::MakeTransformFromFile(RbtParameterFileSou
 RbtSimAnnTransform* MakeSimmulatedAnnealingTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
     const RbtSimAnnTransform::Config& default_config = RbtSimAnnTransform::DEFAULT_CONFIG;
     RbtSimAnnTransform::Config config {
-        .initial_temp=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_START_T, default_config.initial_temp),
-        .final_temp=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_FINAL_T, default_config.final_temp),
-        .num_blocks=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_NUM_BLOCKS, default_config.num_blocks),
-        .block_length=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_BLOCK_LENGTH, default_config.block_length),
-        .scale_chromosome_length=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_SCALE_CHROM_LENGTH, default_config.scale_chromosome_length),
-        .step_size=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_STEP_SIZE, default_config.step_size),
-        .min_accuracy_rate=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_MIN_ACC_RATE, default_config.min_accuracy_rate),
-        .partition_distance=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_PARTITION_DIST, default_config.partition_distance),
-        .partition_frequency=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_PARTITION_FREQ, default_config.partition_frequency),
-        .history_frequency=paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_HISTORY_FREQ, default_config.history_frequency),
+        .initial_temp = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_START_T, default_config.initial_temp),
+        .final_temp = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_FINAL_T, default_config.final_temp),
+        .num_blocks = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_NUM_BLOCKS, default_config.num_blocks),
+        .block_length = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_BLOCK_LENGTH, default_config.block_length),
+        .scale_chromosome_length = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_SCALE_CHROM_LENGTH, default_config.scale_chromosome_length),
+        .step_size = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_STEP_SIZE, default_config.step_size),
+        .min_accuracy_rate = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_MIN_ACC_RATE, default_config.min_accuracy_rate),
+        .partition_distance = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_PARTITION_DIST, default_config.partition_distance),
+        .partition_frequency = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_PARTITION_FREQ, default_config.partition_frequency),
+        .history_frequency = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_HISTORY_FREQ, default_config.history_frequency),
     };
     return new RbtSimAnnTransform(name, config);
 }
 
 RbtGATransform* MakeGeneticAlgorithmTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
-    auto transform = new RbtGATransform(name);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_NEW_FRACTION);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_PCROSSOVER);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_XOVERMUT);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_CMUTATE);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_STEP_SIZE);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_EQUALITY_THRESHOLD);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_NCYCLES);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_NCONVERGENCE);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtGATransform::_HISTORY_FREQ);
-    return transform;
+    const RbtGATransform::Config& default_config = RbtGATransform::DEFAULT_CONFIG;
+    RbtGATransform::Config config {
+      .population_size_fraction_as_new_individuals_per_cycle = paramsPtr->GetParamOrDefault(RbtGATransform::_NEW_FRACTION, default_config.population_size_fraction_as_new_individuals_per_cycle),
+      .crossover_probability = paramsPtr->GetParamOrDefault(RbtGATransform::_PCROSSOVER, default_config.crossover_probability),
+      .cauchy_mutation_after_crossover = paramsPtr->GetParamOrDefault(RbtGATransform::_XOVERMUT, default_config.cauchy_mutation_after_crossover),
+      .use_cauchy_distribution_for_mutations = paramsPtr->GetParamOrDefault(RbtGATransform::_CMUTATE, default_config.use_cauchy_distribution_for_mutations),
+      .relative_step_size = paramsPtr->GetParamOrDefault(RbtGATransform::_STEP_SIZE, default_config.relative_step_size),
+      .equality_threshold = paramsPtr->GetParamOrDefault(RbtGATransform::_EQUALITY_THRESHOLD, default_config.equality_threshold),
+      .max_cycles = paramsPtr->GetParamOrDefault(RbtGATransform::_NCYCLES, default_config.max_cycles),
+      .num_convergence_cycles = paramsPtr->GetParamOrDefault(RbtGATransform::_NCONVERGENCE, default_config.num_convergence_cycles),
+      .history_frequency = paramsPtr->GetParamOrDefault(RbtGATransform::_HISTORY_FREQ, default_config.history_frequency),
+    };
+    return new RbtGATransform(name, config);
 }
 
 RbtAlignTransform* MakeLigandAlignTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -53,7 +53,18 @@ RbtBaseTransform* RbtTransformFactory::Create(const RbtString& strTransformClass
 
 void RbtTransformFactory::AddTransformToAggFromFile(RbtTransformAgg* aggPtr, RbtParameterFileSourcePtr paramsPtr, const RbtString& kind, const RbtString& name) {
     // Create new transform according to the string value of _TRANSFORM parameter
-    RbtBaseTransform* pTransform = Create(kind, name);
+    RbtBaseTransform* pTransform;
+    // Component transforms
+    if (kind == RbtSimAnnTransform::_CT) pTransform = new RbtSimAnnTransform(name);
+    else if (kind == RbtGATransform::_CT) pTransform = new RbtGATransform(name);
+    else if (kind == RbtAlignTransform::_CT) pTransform = new RbtAlignTransform(name);
+    else if (kind == RbtNullTransform::_CT) pTransform = new RbtNullTransform(name);
+    else if (kind == RbtRandLigTransform::_CT) pTransform = new RbtRandLigTransform(name);
+    else if (kind == RbtRandPopTransform::_CT) pTransform = new RbtRandPopTransform(name);
+    else if (kind == RbtSimplexTransform::_CT) pTransform = new RbtSimplexTransform(name);
+    else if (kind == RbtTransformAgg::_CT) pTransform = new RbtTransformAgg(name);
+    else throw RbtBadArgument(_WHERE_, "Unknown transform: " + kind);
+
     // Set all the transform parameters from the rest of the parameters listed
     RbtStringList prmList = paramsPtr->GetParameterList();
     for (RbtStringListConstIter prmIter = prmList.begin(); prmIter != prmList.end(); prmIter++) {

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -22,6 +22,10 @@
 #include "RbtSimAnnTransform.h"
 #include "RbtSimplexTransform.h"
 
+
+void SetParameterIfExistsInSection(RbtBaseTransform* transform, RbtParameterFileSourcePtr paramsPtr, const RbtString& paramName);
+RbtSimAnnTransform* MakeSimmulatedAnnealingTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
+
 // Parameter name which identifies a scoring function definition
 RbtString RbtTransformFactory::_TRANSFORM("TRANSFORM");
 
@@ -79,7 +83,9 @@ void RbtTransformFactory::AddTransformToAggFromFile(RbtTransformAgg* aggPtr, Rbt
     RbtBaseTransform* pTransform;
     // Component transforms
     if (kind == RbtSimAnnTransform::_CT) {
-        pTransform = new RbtSimAnnTransform(name);
+        pTransform = MakeSimmulatedAnnealingTransformFromFile(paramsPtr, name);
+        aggPtr->Add(pTransform);
+        return;
     } else if (kind == RbtGATransform::_CT) {
         pTransform = new RbtGATransform(name);
     } else if (kind == RbtAlignTransform::_CT) {
@@ -114,7 +120,22 @@ void RbtTransformFactory::AddTransformToAggFromFile(RbtTransformAgg* aggPtr, Rbt
     aggPtr->Add(pTransform);
 }
 
-RbtSimAnnTransform* MakeSimmulatedAnnealingTransformFromFile(RbtTransformAgg* aggPtr, const RbtString& name) {
-    auto transform = new RbtSimAnnTransform(name);
+void SetParameterIfExistsInSection(RbtBaseTransform* transform, RbtParameterFileSourcePtr paramsPtr, const RbtString& paramName) {
+    if (paramsPtr->isParameterPresent(paramName))
+        transform->SetParameter(paramName, paramsPtr->GetParameterValueAsString(paramName));
+}
 
+RbtSimAnnTransform* MakeSimmulatedAnnealingTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
+    auto transform = new RbtSimAnnTransform(name);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_START_T);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_FINAL_T);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_BLOCK_LENGTH);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_SCALE_CHROM_LENGTH);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_NUM_BLOCKS);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_STEP_SIZE);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_MIN_ACC_RATE);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_PARTITION_DIST);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_PARTITION_FREQ);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_HISTORY_FREQ);
+    return transform;
 }

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -29,6 +29,7 @@ RbtGATransform* MakeGeneticAlgorithmTransformFromFile(RbtParameterFileSourcePtr 
 RbtAlignTransform* MakeLigandAlignTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 RbtNullTransform* MakeNullTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 RbtRandLigTransform* MakeRandomizeLigandTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
+RbtRandPopTransform* MakeRandomizePopulationTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 
 // Parameter name which identifies a scoring function definition
 RbtString RbtTransformFactory::_TRANSFORM("TRANSFORM");
@@ -181,5 +182,12 @@ RbtNullTransform* MakeNullTransformFromFile(RbtParameterFileSourcePtr paramsPtr,
 RbtRandLigTransform* MakeRandomizeLigandTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
     auto transform = new RbtRandLigTransform(name);
     SetParameterIfExistsInSection(transform, paramsPtr, RbtRandLigTransform::_TORS_STEP);
+    return transform;
+}
+
+RbtRandPopTransform* MakeRandomizePopulationTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
+    auto transform = new RbtRandPopTransform(name);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtRandPopTransform::_POP_SIZE);
+    SetParameterIfExistsInSection(transform, paramsPtr, RbtRandPopTransform::_SCALE_CHROM_LENGTH);
     return transform;
 }

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -159,10 +159,12 @@ static RbtRandLigTransform* MakeRandomizeLigandTransformFromFile(RbtParameterFil
 }
 
 static RbtRandPopTransform* MakeRandomizePopulationTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
-    auto transform = new RbtRandPopTransform(name);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtRandPopTransform::_POP_SIZE);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtRandPopTransform::_SCALE_CHROM_LENGTH);
-    return transform;
+    const RbtRandPopTransform::Config& default_config = RbtRandPopTransform::DEFAULT_CONFIG;
+    RbtRandPopTransform::Config config {
+        .population_size = paramsPtr->GetParamOrDefault(RbtRandPopTransform::_POP_SIZE, default_config.population_size),
+        .scale_chromosome_length = paramsPtr->GetParamOrDefault(RbtRandPopTransform::_SCALE_CHROM_LENGTH, default_config.scale_chromosome_length),
+    };
+    return new RbtRandPopTransform(name, config);
 }
 
 static RbtSimplexTransform* MakeSimplexTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -60,10 +60,9 @@ RbtTransformAgg* RbtTransformFactory::CreateAggFromFile(
 ) {
     // Get list of transform objects to create
     RbtStringList transformList = Rbt::ConvertDelimitedStringToList(strTransformClasses);
-    // If strTransformClasses is empty, then default to reading all sections of the
-    // parameter file for valid transform definitions
-    // In this case we do not throw an error if a particular section
-    // is not a transform, we simply skip it
+    // If strTransformClasses is empty, then default to reading all sections of the parameter file for valid transform definitions
+    // In this case we do not throw an error if a particular section is not a transform, we simply skip it.
+    // This is not used anywhere but not sure if any user of the API needs it.
     RbtBool bThrowError(true);
     if (transformList.empty()) {
         transformList = spPrmSource->GetSectionList();
@@ -103,18 +102,19 @@ RbtBaseTransform* RbtTransformFactory::MakeTransformFromFile(RbtParameterFileSou
 }
 
 RbtSimAnnTransform* MakeSimmulatedAnnealingTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
-    auto transform = new RbtSimAnnTransform(name);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_START_T);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_FINAL_T);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_BLOCK_LENGTH);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_SCALE_CHROM_LENGTH);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_NUM_BLOCKS);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_STEP_SIZE);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_MIN_ACC_RATE);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_PARTITION_DIST);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_PARTITION_FREQ);
-    SetParameterIfExistsInSection(transform, paramsPtr, RbtSimAnnTransform::_HISTORY_FREQ);
-    return transform;
+    return new RbtSimAnnTransform(
+        name,
+        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_START_T, 1000.0),
+        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_FINAL_T, 300.0),
+        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_NUM_BLOCKS, 25),
+        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_BLOCK_LENGTH, 50),
+        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_SCALE_CHROM_LENGTH, true),
+        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_STEP_SIZE, 1.0),
+        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_MIN_ACC_RATE, 0.25),
+        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_PARTITION_DIST, 0.0),
+        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_PARTITION_FREQ, 0),
+        paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_HISTORY_FREQ, 0)
+    );
 }
 
 RbtGATransform* MakeGeneticAlgorithmTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -22,20 +22,32 @@
 #include "RbtSimAnnTransform.h"
 #include "RbtSimplexTransform.h"
 
-
-static RbtSimAnnTransform* MakeSimmulatedAnnealingTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
-static RbtGATransform* MakeGeneticAlgorithmTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
+static RbtSimAnnTransform* MakeSimmulatedAnnealingTransformFromFile(
+    RbtParameterFileSourcePtr paramsPtr, const RbtString& name
+);
+static RbtGATransform* MakeGeneticAlgorithmTransformFromFile(
+    RbtParameterFileSourcePtr paramsPtr, const RbtString& name
+);
 static RbtAlignTransform* MakeLigandAlignTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 static RbtNullTransform* MakeNullTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
-static RbtRandLigTransform* MakeRandomizeLigandTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
-static RbtRandPopTransform* MakeRandomizePopulationTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
+static RbtRandLigTransform* MakeRandomizeLigandTransformFromFile(
+    RbtParameterFileSourcePtr paramsPtr, const RbtString& name
+);
+static RbtRandPopTransform* MakeRandomizePopulationTransformFromFile(
+    RbtParameterFileSourcePtr paramsPtr, const RbtString& name
+);
 static RbtSimplexTransform* MakeSimplexTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
 static RbtTransformAgg* MakeAggregateTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name);
-static void RegisterScoreFunctionOverridesInTransform(RbtBaseTransform* transform, RbtParameterFileSourcePtr paramsPtr);
+static void RegisterScoreFunctionOverridesInTransform(
+    RbtBaseTransform* transform, RbtParameterFileSourcePtr paramsPtr
+);
 
-static RbtAlignTransform::LigandCenterOfMassPlacementStrategy GetLigandCenterOfMassPlacementStrategyFromFile(RbtParameterFileSourcePtr paramsPtr);
-static RbtAlignTransform::LigandAxesAlignmentStrategy GetLigandAxesAlignmentStrategyFromFile(RbtParameterFileSourcePtr paramsPtr);
-
+static RbtAlignTransform::LigandCenterOfMassPlacementStrategy GetLigandCenterOfMassPlacementStrategyFromFile(
+    RbtParameterFileSourcePtr paramsPtr
+);
+static RbtAlignTransform::LigandAxesAlignmentStrategy GetLigandAxesAlignmentStrategyFromFile(
+    RbtParameterFileSourcePtr paramsPtr
+);
 
 // Parameter name which identifies a scoring function definition
 RbtString RbtTransformFactory::_TRANSFORM("TRANSFORM");
@@ -50,7 +62,6 @@ RbtTransformFactory::~RbtTransformFactory() {}
 // Public methods
 ////////////////
 
-
 // Creates an aggregate transform from a parameter file source
 // Each component transform is in a named section, which should minimally contain a TRANSFORM parameter
 // whose value is the class name to instantiate
@@ -62,8 +73,8 @@ RbtTransformAgg* RbtTransformFactory::CreateAggFromFile(
 ) {
     // Get list of transform objects to create
     RbtStringList transformList = Rbt::ConvertDelimitedStringToList(strTransformClasses);
-    // If strTransformClasses is empty, then default to reading all sections of the parameter file for valid transform definitions
-    // In this case we do not throw an error if a particular section is not a transform, we simply skip it.
+    // If strTransformClasses is empty, then default to reading all sections of the parameter file for valid transform
+    // definitions In this case we do not throw an error if a particular section is not a transform, we simply skip it.
     // This is not used anywhere but not sure if any user of the API needs it.
     RbtBool bThrowError(true);
     if (transformList.empty()) {
@@ -74,7 +85,7 @@ RbtTransformAgg* RbtTransformFactory::CreateAggFromFile(
     // Create empty aggregate
     RbtTransformAgg* pTransformAgg(new RbtTransformAgg(strName));
 
-    for (auto& sectionName : transformList) {
+    for (auto& sectionName: transformList) {
         spPrmSource->SetSection(sectionName);
         if (spPrmSource->isParameterPresent(_TRANSFORM)) {
             RbtBaseTransform* transform = MakeTransformFromFile(spPrmSource, sectionName);
@@ -90,54 +101,87 @@ RbtTransformAgg* RbtTransformFactory::CreateAggFromFile(
 }
 
 // Assumes that the fileSource has the appropriate Section set.
-RbtBaseTransform* RbtTransformFactory::MakeTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
-    RbtString kind = paramsPtr->GetParameterValueAsString(_TRANSFORM);   // Force a cast from RbtVariant to String
-    if (kind == RbtSimAnnTransform::_CT) return MakeSimmulatedAnnealingTransformFromFile(paramsPtr, name);
-    else if (kind == RbtGATransform::_CT) return MakeGeneticAlgorithmTransformFromFile(paramsPtr, name);
-    else if (kind == RbtAlignTransform::_CT) return MakeLigandAlignTransformFromFile(paramsPtr, name);
-    else if (kind == RbtNullTransform::_CT) return MakeNullTransformFromFile(paramsPtr, name);
-    else if (kind == RbtRandLigTransform::_CT) return MakeRandomizeLigandTransformFromFile(paramsPtr, name);
-    else if (kind == RbtRandPopTransform::_CT) return MakeRandomizePopulationTransformFromFile(paramsPtr, name);
-    else if (kind == RbtSimplexTransform::_CT) return MakeSimplexTransformFromFile(paramsPtr, name);
-    else if (kind == RbtTransformAgg::_CT) return MakeAggregateTransformFromFile(paramsPtr, name);
-    else throw RbtBadArgument(_WHERE_, "Unknown transform: " + kind);
+RbtBaseTransform* RbtTransformFactory::MakeTransformFromFile(
+    RbtParameterFileSourcePtr paramsPtr, const RbtString& name
+) {
+    RbtString kind = paramsPtr->GetParameterValueAsString(_TRANSFORM);  // Force a cast from RbtVariant to String
+    if (kind == RbtSimAnnTransform::_CT)
+        return MakeSimmulatedAnnealingTransformFromFile(paramsPtr, name);
+    else if (kind == RbtGATransform::_CT)
+        return MakeGeneticAlgorithmTransformFromFile(paramsPtr, name);
+    else if (kind == RbtAlignTransform::_CT)
+        return MakeLigandAlignTransformFromFile(paramsPtr, name);
+    else if (kind == RbtNullTransform::_CT)
+        return MakeNullTransformFromFile(paramsPtr, name);
+    else if (kind == RbtRandLigTransform::_CT)
+        return MakeRandomizeLigandTransformFromFile(paramsPtr, name);
+    else if (kind == RbtRandPopTransform::_CT)
+        return MakeRandomizePopulationTransformFromFile(paramsPtr, name);
+    else if (kind == RbtSimplexTransform::_CT)
+        return MakeSimplexTransformFromFile(paramsPtr, name);
+    else if (kind == RbtTransformAgg::_CT)
+        return MakeAggregateTransformFromFile(paramsPtr, name);
+    else
+        throw RbtBadArgument(_WHERE_, "Unknown transform: " + kind);
 }
 
-static RbtSimAnnTransform* MakeSimmulatedAnnealingTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
+static RbtSimAnnTransform* MakeSimmulatedAnnealingTransformFromFile(
+    RbtParameterFileSourcePtr paramsPtr, const RbtString& name
+) {
     const RbtSimAnnTransform::Config& default_config = RbtSimAnnTransform::DEFAULT_CONFIG;
-    RbtSimAnnTransform::Config config {
+    RbtSimAnnTransform::Config config{
         .initial_temp = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_START_T, default_config.initial_temp),
         .final_temp = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_FINAL_T, default_config.final_temp),
         .num_blocks = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_NUM_BLOCKS, default_config.num_blocks),
         .block_length = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_BLOCK_LENGTH, default_config.block_length),
-        .scale_chromosome_length = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_SCALE_CHROM_LENGTH, default_config.scale_chromosome_length),
+        .scale_chromosome_length = paramsPtr->GetParamOrDefault(
+            RbtSimAnnTransform::_SCALE_CHROM_LENGTH, default_config.scale_chromosome_length
+        ),
         .step_size = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_STEP_SIZE, default_config.step_size),
-        .min_accuracy_rate = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_MIN_ACC_RATE, default_config.min_accuracy_rate),
-        .partition_distance = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_PARTITION_DIST, default_config.partition_distance),
-        .partition_frequency = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_PARTITION_FREQ, default_config.partition_frequency),
-        .history_frequency = paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_HISTORY_FREQ, default_config.history_frequency),
+        .min_accuracy_rate =
+            paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_MIN_ACC_RATE, default_config.min_accuracy_rate),
+        .partition_distance =
+            paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_PARTITION_DIST, default_config.partition_distance),
+        .partition_frequency =
+            paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_PARTITION_FREQ, default_config.partition_frequency),
+        .history_frequency =
+            paramsPtr->GetParamOrDefault(RbtSimAnnTransform::_HISTORY_FREQ, default_config.history_frequency),
     };
     return new RbtSimAnnTransform(name, config);
 }
 
-static RbtGATransform* MakeGeneticAlgorithmTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
+static RbtGATransform* MakeGeneticAlgorithmTransformFromFile(
+    RbtParameterFileSourcePtr paramsPtr, const RbtString& name
+) {
     const RbtGATransform::Config& default_config = RbtGATransform::DEFAULT_CONFIG;
-    RbtGATransform::Config config {
-      .population_size_fraction_as_new_individuals_per_cycle = paramsPtr->GetParamOrDefault(RbtGATransform::_NEW_FRACTION, default_config.population_size_fraction_as_new_individuals_per_cycle),
-      .crossover_probability = paramsPtr->GetParamOrDefault(RbtGATransform::_PCROSSOVER, default_config.crossover_probability),
-      .cauchy_mutation_after_crossover = paramsPtr->GetParamOrDefault(RbtGATransform::_XOVERMUT, default_config.cauchy_mutation_after_crossover),
-      .use_cauchy_distribution_for_mutations = paramsPtr->GetParamOrDefault(RbtGATransform::_CMUTATE, default_config.use_cauchy_distribution_for_mutations),
-      .relative_step_size = paramsPtr->GetParamOrDefault(RbtGATransform::_STEP_SIZE, default_config.relative_step_size),
-      .equality_threshold = paramsPtr->GetParamOrDefault(RbtGATransform::_EQUALITY_THRESHOLD, default_config.equality_threshold),
-      .max_cycles = paramsPtr->GetParamOrDefault(RbtGATransform::_NCYCLES, default_config.max_cycles),
-      .num_convergence_cycles = paramsPtr->GetParamOrDefault(RbtGATransform::_NCONVERGENCE, default_config.num_convergence_cycles),
-      .history_frequency = paramsPtr->GetParamOrDefault(RbtGATransform::_HISTORY_FREQ, default_config.history_frequency),
+    RbtGATransform::Config config{
+        .population_size_fraction_as_new_individuals_per_cycle = paramsPtr->GetParamOrDefault(
+            RbtGATransform::_NEW_FRACTION, default_config.population_size_fraction_as_new_individuals_per_cycle
+        ),
+        .crossover_probability =
+            paramsPtr->GetParamOrDefault(RbtGATransform::_PCROSSOVER, default_config.crossover_probability),
+        .cauchy_mutation_after_crossover =
+            paramsPtr->GetParamOrDefault(RbtGATransform::_XOVERMUT, default_config.cauchy_mutation_after_crossover),
+        .use_cauchy_distribution_for_mutations = paramsPtr->GetParamOrDefault(
+            RbtGATransform::_CMUTATE, default_config.use_cauchy_distribution_for_mutations
+        ),
+        .relative_step_size =
+            paramsPtr->GetParamOrDefault(RbtGATransform::_STEP_SIZE, default_config.relative_step_size),
+        .equality_threshold =
+            paramsPtr->GetParamOrDefault(RbtGATransform::_EQUALITY_THRESHOLD, default_config.equality_threshold),
+        .max_cycles = paramsPtr->GetParamOrDefault(RbtGATransform::_NCYCLES, default_config.max_cycles),
+        .num_convergence_cycles =
+            paramsPtr->GetParamOrDefault(RbtGATransform::_NCONVERGENCE, default_config.num_convergence_cycles),
+        .history_frequency =
+            paramsPtr->GetParamOrDefault(RbtGATransform::_HISTORY_FREQ, default_config.history_frequency),
     };
     return new RbtGATransform(name, config);
 }
 
-static RbtAlignTransform* MakeLigandAlignTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {    
-    RbtAlignTransform::Config config {
+static RbtAlignTransform* MakeLigandAlignTransformFromFile(
+    RbtParameterFileSourcePtr paramsPtr, const RbtString& name
+) {
+    RbtAlignTransform::Config config{
         .center_of_mass_placement_strategy = GetLigandCenterOfMassPlacementStrategyFromFile(paramsPtr),
         .axes_alignment_strategy = GetLigandAxesAlignmentStrategyFromFile(paramsPtr),
     };
@@ -149,32 +193,43 @@ static RbtNullTransform* MakeNullTransformFromFile(RbtParameterFileSourcePtr par
     return new RbtNullTransform(name);
 }
 
-static RbtRandLigTransform* MakeRandomizeLigandTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
+static RbtRandLigTransform* MakeRandomizeLigandTransformFromFile(
+    RbtParameterFileSourcePtr paramsPtr, const RbtString& name
+) {
     const RbtRandLigTransform::Config& default_config = RbtRandLigTransform::DEFAULT_CONFIG;
-    RbtRandLigTransform::Config config {
+    RbtRandLigTransform::Config config{
         .torsion_step = paramsPtr->GetParamOrDefault(RbtRandLigTransform::_TORS_STEP, default_config.torsion_step),
     };
     return new RbtRandLigTransform(name, config);
 }
 
-static RbtRandPopTransform* MakeRandomizePopulationTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
+static RbtRandPopTransform* MakeRandomizePopulationTransformFromFile(
+    RbtParameterFileSourcePtr paramsPtr, const RbtString& name
+) {
     const RbtRandPopTransform::Config& default_config = RbtRandPopTransform::DEFAULT_CONFIG;
-    RbtRandPopTransform::Config config {
-        .population_size = paramsPtr->GetParamOrDefault(RbtRandPopTransform::_POP_SIZE, default_config.population_size),
-        .scale_chromosome_length = paramsPtr->GetParamOrDefault(RbtRandPopTransform::_SCALE_CHROM_LENGTH, default_config.scale_chromosome_length),
+    RbtRandPopTransform::Config config{
+        .population_size =
+            paramsPtr->GetParamOrDefault(RbtRandPopTransform::_POP_SIZE, default_config.population_size),
+        .scale_chromosome_length = paramsPtr->GetParamOrDefault(
+            RbtRandPopTransform::_SCALE_CHROM_LENGTH, default_config.scale_chromosome_length
+        ),
     };
     return new RbtRandPopTransform(name, config);
 }
 
 static RbtSimplexTransform* MakeSimplexTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
     const RbtSimplexTransform::Config& default_config = RbtSimplexTransform::DEFAULT_CONFIG;
-    RbtSimplexTransform::Config config {
+    RbtSimplexTransform::Config config{
         .max_calls = paramsPtr->GetParamOrDefault(RbtSimplexTransform::_MAX_CALLS, default_config.max_calls),
         .num_cycles = paramsPtr->GetParamOrDefault(RbtSimplexTransform::_NCYCLES, default_config.num_cycles),
-        .stopping_step_length = paramsPtr->GetParamOrDefault(RbtSimplexTransform::_STOPPING_STEP_LENGTH, default_config.stopping_step_length),
-        .convergence_threshold = paramsPtr->GetParamOrDefault(RbtSimplexTransform::_CONVERGENCE, default_config.convergence_threshold),
+        .stopping_step_length = paramsPtr->GetParamOrDefault(
+            RbtSimplexTransform::_STOPPING_STEP_LENGTH, default_config.stopping_step_length
+        ),
+        .convergence_threshold =
+            paramsPtr->GetParamOrDefault(RbtSimplexTransform::_CONVERGENCE, default_config.convergence_threshold),
         .step_size = paramsPtr->GetParamOrDefault(RbtSimplexTransform::_STEP_SIZE, default_config.step_size),
-        .partition_distribution = paramsPtr->GetParamOrDefault(RbtSimplexTransform::_PARTITION_DIST, default_config.partition_distribution),
+        .partition_distribution =
+            paramsPtr->GetParamOrDefault(RbtSimplexTransform::_PARTITION_DIST, default_config.partition_distribution),
     };
     return new RbtSimplexTransform(name, config);
 }
@@ -183,23 +238,27 @@ static RbtTransformAgg* MakeAggregateTransformFromFile(RbtParameterFileSourcePtr
     return new RbtTransformAgg(name);
 }
 
-static void RegisterScoreFunctionOverridesInTransform(RbtBaseTransform* transform, RbtParameterFileSourcePtr paramsPtr) {
+static void RegisterScoreFunctionOverridesInTransform(
+    RbtBaseTransform* transform, RbtParameterFileSourcePtr paramsPtr
+) {
     // Set all the transform parameters from the rest of the parameters listed
-    for (auto& paramName : paramsPtr->GetParameterList()) {
+    for (auto& paramName: paramsPtr->GetParameterList()) {
         // Look for scoring function request (PARAM@SF). Only SetParamRequest currently supported
         // Parameters of the individual transformers are explicitly set by their respective constructor functions
         // So we only look for score function overrides.
         RbtStringList compList = Rbt::ConvertDelimitedStringToList(paramName, "@");
         if (compList.size() == 2) {
-            RbtRequestPtr spReq(new RbtSFSetParamRequest(
-                compList[1], compList[0], paramsPtr->GetParameterValueAsString(paramName)
-            ));
+            RbtRequestPtr spReq(
+                new RbtSFSetParamRequest(compList[1], compList[0], paramsPtr->GetParameterValueAsString(paramName))
+            );
             transform->AddSFRequest(spReq);
         }
     }
 }
 
-static RbtAlignTransform::LigandCenterOfMassPlacementStrategy GetLigandCenterOfMassPlacementStrategyFromFile(RbtParameterFileSourcePtr paramsPtr) {
+static RbtAlignTransform::LigandCenterOfMassPlacementStrategy GetLigandCenterOfMassPlacementStrategyFromFile(
+    RbtParameterFileSourcePtr paramsPtr
+) {
     if (paramsPtr->isParameterPresent(RbtAlignTransform::_COM)) {
         RbtString placement_strategy_val = paramsPtr->GetParameterValueAsString(RbtAlignTransform::_COM);
         if (placement_strategy_val == "ALIGN")
@@ -207,12 +266,16 @@ static RbtAlignTransform::LigandCenterOfMassPlacementStrategy GetLigandCenterOfM
         else if (placement_strategy_val == "RANDOM")
             return RbtAlignTransform::LigandCenterOfMassPlacementStrategy::COM_RANDOM;
         else
-            throw RbtBadArgument(_WHERE_, "Invalid ligand center of mass placement strategy: " + placement_strategy_val);
+            throw RbtBadArgument(
+                _WHERE_, "Invalid ligand center of mass placement strategy: " + placement_strategy_val
+            );
     } else
         return RbtAlignTransform::DEFAULT_CONFIG.center_of_mass_placement_strategy;
 }
 
-static RbtAlignTransform::LigandAxesAlignmentStrategy GetLigandAxesAlignmentStrategyFromFile(RbtParameterFileSourcePtr paramsPtr) {
+static RbtAlignTransform::LigandAxesAlignmentStrategy GetLigandAxesAlignmentStrategyFromFile(
+    RbtParameterFileSourcePtr paramsPtr
+) {
     if (paramsPtr->isParameterPresent(RbtAlignTransform::_AXES)) {
         RbtString alignment_strategy_val = paramsPtr->GetParameterValueAsString(RbtAlignTransform::_AXES);
         if (alignment_strategy_val == "ALIGN")
@@ -220,7 +283,7 @@ static RbtAlignTransform::LigandAxesAlignmentStrategy GetLigandAxesAlignmentStra
         else if (alignment_strategy_val == "RANDOM")
             return RbtAlignTransform::LigandAxesAlignmentStrategy::AXES_RANDOM;
         else
-            throw RbtBadArgument(_WHERE_, "Invalid ligand axes alignment strategy: " + alignment_strategy_val); 
+            throw RbtBadArgument(_WHERE_, "Invalid ligand axes alignment strategy: " + alignment_strategy_val);
     } else
         return RbtAlignTransform::DEFAULT_CONFIG.axes_alignment_strategy;
 }

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -39,15 +39,23 @@ void RbtTransformFactory::AddTransformToAggFromFile(RbtTransformAgg* aggPtr, Rbt
     // Create new transform according to the string value of _TRANSFORM parameter
     RbtBaseTransform* pTransform;
     // Component transforms
-    if (kind == RbtSimAnnTransform::_CT) pTransform = new RbtSimAnnTransform(name);
-    else if (kind == RbtGATransform::_CT) pTransform = new RbtGATransform(name);
-    else if (kind == RbtAlignTransform::_CT) pTransform = new RbtAlignTransform(name);
-    else if (kind == RbtNullTransform::_CT) pTransform = new RbtNullTransform(name);
-    else if (kind == RbtRandLigTransform::_CT) pTransform = new RbtRandLigTransform(name);
-    else if (kind == RbtRandPopTransform::_CT) pTransform = new RbtRandPopTransform(name);
-    else if (kind == RbtSimplexTransform::_CT) pTransform = new RbtSimplexTransform(name);
-    else if (kind == RbtTransformAgg::_CT) pTransform = new RbtTransformAgg(name);
-    else throw RbtBadArgument(_WHERE_, "Unknown transform: " + kind);
+    if (kind == RbtSimAnnTransform::_CT) {
+        pTransform = new RbtSimAnnTransform(name);
+    } else if (kind == RbtGATransform::_CT) {
+        pTransform = new RbtGATransform(name);
+    } else if (kind == RbtAlignTransform::_CT) {
+        pTransform = new RbtAlignTransform(name);
+    } else if (kind == RbtNullTransform::_CT) {
+        pTransform = new RbtNullTransform(name);
+    } else if (kind == RbtRandLigTransform::_CT) {
+        pTransform = new RbtRandLigTransform(name);
+    } else if (kind == RbtRandPopTransform::_CT) {
+        pTransform = new RbtRandPopTransform(name);
+    } else if (kind == RbtSimplexTransform::_CT) {
+        pTransform = new RbtSimplexTransform(name);
+    } else if (kind == RbtTransformAgg::_CT) {
+        pTransform = new RbtTransformAgg(name);
+    } else throw RbtBadArgument(_WHERE_, "Unknown transform: " + kind);
 
     // Set all the transform parameters from the rest of the parameters listed
     RbtStringList prmList = paramsPtr->GetParameterList();

--- a/src/lib/RbtTransformFactory.cxx
+++ b/src/lib/RbtTransformFactory.cxx
@@ -77,6 +77,8 @@ RbtTransformAgg* RbtTransformFactory::CreateAggFromFile(
         spPrmSource->SetSection(sectionName);
         if (spPrmSource->isParameterPresent(_TRANSFORM)) {
             RbtBaseTransform* transform = MakeTransformFromFile(spPrmSource, sectionName);
+            // All examples + the docs instruct to use NullTransform to set the SF overrides, nevertheless
+            // it is possible to set the overrides in an arbitrary transform.
             RegisterScoreFunctionOverridesInTransform(transform, spPrmSource);
             pTransformAgg->Add(transform);
         } else if (bThrowError) {
@@ -86,14 +88,7 @@ RbtTransformAgg* RbtTransformFactory::CreateAggFromFile(
     return pTransformAgg;
 }
 
-// Assumes that the file source is pointing to the appropriate section
-void RbtTransformFactory::AddTransformToAggFromFile(RbtTransformAgg* aggPtr, RbtParameterFileSourcePtr paramsPtr, const RbtString& kind, const RbtString& name) {
-    // Create new transform according to the string value of _TRANSFORM parameter
-    RbtBaseTransform* pTransform = MakeTransformFromFile(paramsPtr, name);
-    RegisterScoreFunctionOverridesInTransform(pTransform, paramsPtr);
-    aggPtr->Add(pTransform);
-}
-
+// Assumes that the fileSource has the appropriate Section set.
 RbtBaseTransform* RbtTransformFactory::MakeTransformFromFile(RbtParameterFileSourcePtr paramsPtr, const RbtString& name) {
     RbtString kind = paramsPtr->GetParameterValueAsString(_TRANSFORM);   // Force a cast from RbtVariant to String
     if (kind == RbtSimAnnTransform::_CT) return MakeSimmulatedAnnealingTransformFromFile(paramsPtr, name);


### PR DESCRIPTION
## Description
As most entities in the project transforms were storing their configuration in a dictionary defined in `RbtParamHandler`, several steps higher in the inheritance hierarchy. This made it very difficult to understand which configuration each transform needed, which ones were the default values, and which value was being used at any given point in time.

## Proposed changes
To address the above explained we've made the parameters required by each one of the transforms explicit. Now each transform defines a `Config` struct with their respective configuration and transform constructors now accept this configuration instead of having to set arbitrary parameters passing strings as we did before. The TransformFactory builds transforms by grabbing the necessary values from the ParameterSource internal state and building the appropriate config for each transform, explicitly stating which fields are needed instead of dynamically iterating through everything as we did before