### PR TITLE
macOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # rDock
+
 [![.github/workflows/build_matrix.yml](https://github.com/CBDD/rDock/actions/workflows/build_matrix.yml/badge.svg?branch=main)](https://github.com/CBDD/rDock/actions/workflows/build_matrix.yml)
 
-* [Quick start guide](#quick-start-guide)
-    + [Requirements](#requirements)
-    + [Compilation](#compilation)
-    + [Testing](#testing)
-    + [Installation](#installation)
-    + [Next steps](#next-steps)
-* [rDock legacy version](#rdock-legacy-version)
+- [Quick start guide](#quick-start-guide)
+  - [Requirements](#requirements)
+  - [Compilation](#compilation)
+  - [Testing](#testing)
+  - [Installation](#installation)
+  - [Next steps](#next-steps)
+- [rDock legacy version](#rdock-legacy-version)
 
 ## Quick start guide
 
@@ -19,15 +20,21 @@ In order to install precompiled binaries, you can follow the same steps as the [
 
 make sure the following requirements are installed and available:
 
-* make
-* a c++ compiler (g++ by default)
-* popt and development headers (libpopt0 and libpopt-dev in ubuntu)
-* git (optional if you download the code directly)
+- make
+- a c++ compiler (g++ by default)
+- popt and development headers (libpopt0 and libpopt-dev in ubuntu)
+- git (optional if you download the code directly)
 
 if you're running ubuntu, you can get all of them by running
 
 ```
 sudo apt update && sudo apt install -y make git libpopt0 libpopt-dev g++
+```
+
+if you're running `macOS`, make sure to use gcc instead of clang. You can install gcc and popt using homebrew
+
+```
+brew install gcc popt
 ```
 
 you can also check requirements for other officially supported distributions in the [Dockerfiles](https://github.com/CBDD/rDock/blob/main/.github/docker) used for CI
@@ -42,7 +49,15 @@ cd rDock
 make
 ```
 
-if you have multiple cores available, you may want to speed up the build process running make like this (replace 4 with the number of parallel processes you'd like to run)  
+on `macOS`, you may need to run `export CC=gcc` before running make in order to use gcc instead of clang. Here is an example for gcc-14 installed with homebrew:
+
+```
+export CC=/opt/homebrew/Cellar/gcc/14.2.0_1/bin/gcc-14
+export CXX=/opt/homebrew/Cellar/gcc/14.2.0_1/bin/g++-14
+```
+
+if you have multiple cores available, you may want to speed up the build process running make like this (replace 4 with the number of parallel processes you'd like to run)
+
 ```
 make -j 4
 ```
@@ -63,7 +78,6 @@ select the location for rDock binaries, library and development headers to be in
 
 then set the PREFIX environment variable to point to this folder, for example ~/.local
 
-
 ```
 PREFIX=~/.local make install
 ```
@@ -82,16 +96,21 @@ export LD_LIBRARY_PATH=~/.local/lib:$LD_LIBRARY_PATH
 export RBT_ROOT=~/.local/rDock
 ```
 
+on `macOS`, LD_LIBRARY_PATH needs to be replaced by `DYLD_LIBRARY_PATH`
+
 you may want to add these lines to your profile/configuration files like ~/.bashrc
 
 ### Next steps
 
-If everything went well, you should be able to run rDock binaries like `rbcavity` or `rbdock`.  
+If everything went well, you should be able to run rDock binaries like `rbcavity` or `rbdock`.
 You can find more information about the available tools in the [rDock documentation](https://rdock.github.io/documentation/), including several tutorials to get you started.
 
 ## rDock legacy version
 
-with each new release, we try to improve the build system and the codebase, making it easier to maintain and to add new features, and the new features are not always fully compatible with the old ones.  
-for this reason, the legacy version of rDock was frozen and will only receive critical bug fixes.  
+with each new release, we try to improve the build system and the codebase, making it easier to maintain and to add new features, and the new features are not always fully compatible with the old ones.
+for this reason, the legacy version of rDock was frozen and will only receive critical bug fixes.
 you can find the [latest legacy release here](https://github.com/CBDD/rDock/releases/tag/v24.04.204-legacy)
 
+```
+
+```

--- a/import/simplex/include/NMObjective.h
+++ b/import/simplex/include/NMObjective.h
@@ -6,7 +6,12 @@
 #if !defined _userfile_
 #define _userfile_
 
+#if defined(__APPLE__) || defined(__FreeBSD__)
+#include <stdlib.h>
+#else
 #include <malloc.h>
+#endif
+
 #include <vector>
 
 double getInitialStep();


### PR DESCRIPTION
Dear rDock members, we are developing unofficial rDock plugin for `Horus` at the Barcelona Supercomputing Center. you can learn more about `Horus` [in the official webpage](horus.bsc.es).

`Horus` natively supports Linux and macOS and we wanted to distribute the plugin for both platforms. In order to do so, I had to compile rDock on macOS manually. For it to work I had to slightly modify some parts of the code and the makefiles. 

During my tests, I did not see any change in the results outputs and the application is working flawlessly. I hope that this macOS support allows rDock to run on more platforms!